### PR TITLE
Releases Documentation Change COPS-863

### DIFF
--- a/commands/releases/contract.go
+++ b/commands/releases/contract.go
@@ -18,6 +18,8 @@ var Cmd = models.Command{
 		"A release is automatically created each time you perform a git push. " +
 		"The release is tagged with the git SHA of the commit. " +
 		"Releases are a way of tagging specific points in time of your git history. " +
+		"By default, the last three releases will be kept. " +
+		"Please contact Support if you require more than the last three releases to be retained. " +
 		"You can rollback to a specific release by using the [rollback](#rollback) command. " +
 		"The releases command cannot be run directly but has sub commands.",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {


### PR DESCRIPTION
Add a statement showing how many past releases will be kept
We should specify that we will only be keeping the last three releases. We prune the previous releases to save on disk space on docker registry