### PR TITLE
3.5.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/
 public/
 Godeps/_workspace
 docs/cli-docs.md
+.datica_update
+cli

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Welcome to the Datica CLI (formerly Catalyze).
 
+# development version
+
+> This branch is a development version of the Datica CLI. Any CLI based off of this branch is not supported by Datica. Please download the latest release [here](https://github.com/daticahealth/cli/releases).
+
 ## Upgrading from `catalyze` to `datica`
 
 To upgrade your CLI from `catalyze` to `datica` perform the following steps:
@@ -23,7 +27,7 @@ Once downloaded, the CLI will automatically update itself when a new version bec
 
 **PLEASE NOTE** You **must** put the CLI binary in a location for which you have write permissions. Without write permissions, the CLI will not automatically update and you will have to update manually by visiting the github repo and downloading the latest binary.
 
-## Version 3.4.2
+## Version 3.5.0
 
 ***Due to changes to Datica's API and authentication, existing environment associations need to be recreated if you have previously made them with an earlier version of the CLI (< 3.0)***
 
@@ -35,15 +39,15 @@ For all 64 bit users, choose the `amd64` version of your OS. For all 32 bit user
 
 ### Darwin (Apple Mac)
 
- * [datica\_3.4.2\_darwin\_386.zip](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_darwin_386.zip)
- * [datica\_3.4.2\_darwin\_amd64.zip](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_darwin_amd64.zip)
+ * [datica\_3.5.0\_darwin\_386.zip](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_darwin_386.zip)
+ * [datica\_3.5.0\_darwin\_amd64.zip](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_darwin_amd64.zip)
 
 ### Linux
 
- * [datica\_3.4.2\_linux\_386.tar.gz](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_linux_386.tar.gz)
- * [datica\_3.4.2\_linux\_amd64.tar.gz](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_linux_amd64.tar.gz)
+ * [datica\_3.5.0\_linux\_386.tar.gz](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_linux_386.tar.gz)
+ * [datica\_3.5.0\_linux\_amd64.tar.gz](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_linux_amd64.tar.gz)
 
 ### MS Windows
 
- * [datica\_3.4.2\_windows\_386.zip](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_windows_386.zip)
- * [datica\_3.4.2\_windows\_amd64.zip](https://github.com/daticahealth/cli/releases/download/3.4.2/datica_3.4.2_windows_amd64.zip)
+ * [datica\_3.5.0\_windows\_386.zip](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_windows_386.zip)
+ * [datica\_3.5.0\_windows\_amd64.zip](https://github.com/daticahealth/cli/releases/download/3.5.0/datica_3.5.0_windows_amd64.zip)

--- a/commands/associated/associated_test.go
+++ b/commands/associated/associated_test.go
@@ -1,58 +1,37 @@
 package associated
 
 import (
-	"regexp"
 	"testing"
 
+	"github.com/daticahealth/cli/models"
 	"github.com/daticahealth/cli/test"
 )
 
-const (
-	commandName    = "associated"
-	standardOutput = `ctest:
-\s+Environment ID:[\s]+[^\s]+
-\s+Environment Name: cli-integration-tests
-\s+Service ID:[\s]+[^\s]+
-\s+Associated at:[\s]+[^\s]+
-\s+Pod:[\s]+[^\s]+
-\s+Organization ID:[\s]+[^\s]+`
-)
-
-var associatedTests = []struct {
-	associateFirst bool
-	expectErr      bool
-	expectedOutput string
-}{
-	{true, false, standardOutput},
-	{false, false, "No environments have been associated"},
+func TestAssociated(t *testing.T) {
+	settings := &models.Settings{
+		Environments: map[string]models.AssociatedEnv{
+			test.Alias: models.AssociatedEnv{
+				Name:          test.EnvName,
+				EnvironmentID: test.EnvID,
+				ServiceID:     test.SvcLabel,
+				Directory:     "",
+				Pod:           test.Pod,
+				OrgID:         test.OrgID,
+			},
+		},
+	}
+	err := CmdAssociated(New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
 }
 
-func TestAssociated(t *testing.T) {
-	if err := test.SetUpGitRepo(); err != nil {
-		t.Error(err)
-		t.Fail()
+func TestAssociatedNoAssociations(t *testing.T) {
+	settings := &models.Settings{
+		Environments: map[string]models.AssociatedEnv{},
 	}
-	for _, data := range associatedTests {
-		t.Logf("Data: %+v", data)
-		if err := test.ClearAssociations(); err != nil {
-			t.Error(err)
-			continue
-		}
-		if data.associateFirst {
-			if err := test.SetUpAssociation(); err != nil {
-				t.Error(err)
-				continue
-			}
-		}
-		r := regexp.MustCompile(data.expectedOutput)
-		output, err := test.RunCommand(test.BinaryName, []string{commandName})
-		if err != nil != data.expectErr {
-			t.Errorf("Unexpected error: %s", output)
-			continue
-		}
-		if !r.MatchString(output) {
-			t.Errorf("Expected: %s. Found: %s", data.expectedOutput, output)
-			continue
-		}
+	err := CmdAssociated(New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }

--- a/commands/certs/list_test.go
+++ b/commands/certs/list_test.go
@@ -1,67 +1,36 @@
 package certs
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/test"
 )
 
-const (
-	certsListCommandName    = "certs"
-	certsListSubcommandName = "list"
-	certsListStandardOutput = `NAME
-sbox0513063.catalyzeapps.com
-`
-)
-
-var certListTests = []struct {
-	env            string
-	expectErr      bool
-	expectedOutput string
-}{
-	{test.Alias, false, certsListStandardOutput},
-	{"bad-env", true, "\033[31m\033[1m[fatal] \033[0mNo environment named \"bad-env\" has been associated. Run \"datica associated\" to see what environments have been associated or run \"datica associate\" from a local git repo to create a new association\n"},
-}
-
 func TestCertsList(t *testing.T) {
-	if err := test.SetUpGitRepo(); err != nil {
-		t.Error(err)
-		return
-	}
-	if err := test.SetUpAssociation(); err != nil {
-		t.Error(err)
-		return
-	}
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, `[{"name":"cert1"},{"name":"cert2"}]`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+		},
+	)
 
-	for _, data := range certListTests {
-		t.Logf("Data: %+v", data)
-		args := []string{"-E", data.env}
-		args = append(args, certsListCommandName, certsListSubcommandName)
-		output, err := test.RunCommand(test.BinaryName, args)
-		if err != nil != data.expectErr {
-			t.Errorf("Unexpected error: %s", output)
-			continue
-		}
-		if output != data.expectedOutput {
-			t.Errorf("Expected: %s. Found: %s", data.expectedOutput, output)
-			continue
-		}
-	}
-}
+	// test
+	err := CmdList(New(settings), services.New(settings))
 
-func TestCertsListNoAssociation(t *testing.T) {
-	if err := test.ClearAssociations(); err != nil {
-		t.Error(err)
-		return
-	}
-	output, err := test.RunCommand(test.BinaryName, []string{certsListCommandName, certsListSubcommandName})
-	if err == nil {
-		t.Errorf("Expected error but no error returned: %s", output)
-		return
-	}
-	expectedOutput := "\033[31m\033[1m[fatal] \033[0mNo Datica environment has been associated. Run \"datica associate\" from a local git repo first\n"
-	if output != expectedOutput {
-		t.Errorf("Expected: %s. Found: %s", expectedOutput, output)
-		return
+	// assert
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
 }

--- a/commands/certs/rm_test.go
+++ b/commands/certs/rm_test.go
@@ -1,75 +1,49 @@
 package certs
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/test"
 )
 
-const (
-	certsRmCommandName    = "certs"
-	certsRmSubcommandName = "rm"
-	certsRmStandardOutput = "Removed 'example.com'\n"
-)
-
 var certRmTests = []struct {
-	env            string
-	name           string
-	expectErr      bool
-	expectedOutput string
+	hostname  string
+	expectErr bool
 }{
-	{test.Alias, certName, false, certsRmStandardOutput},
-	{"bad-env", certName, true, "\033[31m\033[1m[fatal] \033[0mNo environment named \"bad-env\" has been associated. Run \"datica associated\" to see what environments have been associated or run \"datica associate\" from a local git repo to create a new association\n"},
-	{test.Alias, "bad-cert-name", true, "\033[31m\033[1m[fatal] \033[0m(92002) Cert Not Found: Could not find a cert with the given name associated with the service.\n"},
+	{certName, false},
+	{"bad-cert-name", true},
 }
 
 func TestCertsRm(t *testing.T) {
-	if err := test.SetUpGitRepo(); err != nil {
-		t.Error(err)
-		return
-	}
-	if err := test.SetUpAssociation(); err != nil {
-		t.Error(err)
-		return
-	}
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs/"+certName,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "DELETE")
+			fmt.Fprint(w, "")
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+		},
+	)
 
 	for _, data := range certRmTests {
 		t.Logf("Data: %+v", data)
-		if !data.expectErr {
-			if output, err := test.RunCommand(test.BinaryName, []string{"-E", test.Alias, certsCreateCommandName, certsCreateSubcommandName, certName, pubKeyPath, privKeyPath}); err != nil {
-				t.Errorf("Error creating cert: %s - %s", err, output)
-				continue
-			}
-		}
-		args := []string{"-E", data.env, certsRmCommandName, certsRmSubcommandName}
-		if len(data.name) != 0 {
-			args = append(args, data.name)
-		}
-		output, err := test.RunCommand(test.BinaryName, args)
-		if err != nil != data.expectErr {
-			t.Errorf("Unexpected error: %s", output)
-			continue
-		}
-		if output != data.expectedOutput {
-			t.Errorf("Expected: %s. Found: %s", data.expectedOutput, output)
-			continue
-		}
-	}
-}
 
-func TestCertsRmNoAssociation(t *testing.T) {
-	if err := test.ClearAssociations(); err != nil {
-		t.Error(err)
-		return
-	}
-	output, err := test.RunCommand(test.BinaryName, []string{certsRmCommandName, certsRmSubcommandName, certName})
-	if err == nil {
-		t.Errorf("Expected error but no error returned: %s", output)
-		return
-	}
-	expectedOutput := "\033[31m\033[1m[fatal] \033[0mNo Datica environment has been associated. Run \"datica associate\" from a local git repo first\n"
-	if output != expectedOutput {
-		t.Errorf("Expected: %s. Found: %s", expectedOutput, output)
-		return
+		// test
+		err := CmdRm(data.hostname, New(settings), services.New(settings))
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
 	}
 }

--- a/commands/certs/update_test.go
+++ b/commands/certs/update_test.go
@@ -1,99 +1,58 @@
 package certs
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/commands/ssl"
 	"github.com/daticahealth/cli/test"
 )
 
-const (
-	certsUpdateCommandName    = "certs"
-	certsUpdateSubcommandName = "update"
-	certsUpdateStandardOutput = `Updated 'example.com'
-To make your updated cert go live, you must redeploy your service proxy with the "datica redeploy service_proxy" command
-`
-)
-
 var certUpdateTests = []struct {
-	env            string
-	name           string
-	pubKeyPath     string
-	privKeyPath    string
-	selfSigned     bool
-	skipResolve    bool
-	expectErr      bool
-	expectedOutput string
+	hostname    string
+	pubKeyPath  string
+	privKeyPath string
+	selfSigned  bool
+	resolve     bool
+	expectErr   bool
 }{
-	{test.Alias, certName, pubKeyPath, privKeyPath, true, false, false, certsUpdateStandardOutput},
-	{test.Alias, certName, invalidPath, privKeyPath, true, false, true, "\033[31m\033[1m[fatal] \033[0mA cert does not exist at path 'invalid-file.pem'\n"},
-	{test.Alias, certName, pubKeyPath, invalidPath, true, false, true, "\033[31m\033[1m[fatal] \033[0mA private key does not exist at path 'invalid-file.pem'\n"},
-	{test.Alias, certName, pubKeyPath, privKeyPath, false, false, false, "Incomplete certificate chain found, attempting to resolve this\n" + certsUpdateStandardOutput},
-	{test.Alias, certName, pubKeyPath, privKeyPath, true, true, false, certsUpdateStandardOutput},
-	{"bad-env", certName, pubKeyPath, privKeyPath, true, false, true, "\033[31m\033[1m[fatal] \033[0mNo environment named \"bad-env\" has been associated. Run \"datica associated\" to see what environments have been associated or run \"datica associate\" from a local git repo to create a new association\n"},
-	{test.Alias, "bad-cert-name", pubKeyPath, privKeyPath, true, false, true, "\033[31m\033[1m[fatal] \033[0m(92002) Cert Not Found: Could not find a cert with the given name associated with the service.\n"},
+	{certName, pubKeyPath, privKeyPath, true, false, false},
+	{certName, invalidPath, privKeyPath, true, false, true}, // invalid cert path
+	{certName, pubKeyPath, invalidPath, true, false, true},  // invalid key path
+	{certName, pubKeyPath, privKeyPath, false, false, true}, // cert not signed by CA
+	{certName, pubKeyPath, privKeyPath, true, true, false},
+	{"bad-cert-name", pubKeyPath, privKeyPath, true, false, true},
 }
 
 func TestCertsUpdate(t *testing.T) {
-	if err := test.SetUpGitRepo(); err != nil {
-		t.Error(err)
-		return
-	}
-	if err := test.SetUpAssociation(); err != nil {
-		t.Error(err)
-		return
-	}
-	if output, err := test.RunCommand(test.BinaryName, []string{"-E", test.Alias, certsCreateCommandName, certsCreateSubcommandName, certName, pubKeyPath, privKeyPath}); err != nil {
-		t.Errorf("Error creating cert: %s - %s", err, output)
-		return
-	}
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs/"+certName,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "PUT")
+			fmt.Fprint(w, fmt.Sprintf(`{"name":"%s"}`, certName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+		},
+	)
 
 	for _, data := range certUpdateTests {
 		t.Logf("Data: %+v", data)
-		args := []string{"-E", data.env, certsUpdateCommandName, certsUpdateSubcommandName}
-		if len(data.name) != 0 {
-			args = append(args, data.name)
-		}
-		if len(data.pubKeyPath) != 0 {
-			args = append(args, data.pubKeyPath)
-		}
-		if len(data.privKeyPath) != 0 {
-			args = append(args, data.privKeyPath)
-		}
-		if data.selfSigned {
-			args = append(args, "-s")
-		}
-		if data.skipResolve {
-			args = append(args, "-r=false")
-		}
-		output, err := test.RunCommand(test.BinaryName, args)
-		if err != nil != data.expectErr {
-			t.Errorf("Unexpected error: %s", output)
-			continue
-		}
-		if output != data.expectedOutput {
-			t.Errorf("Expected: %s. Found: %s", data.expectedOutput, output)
-			continue
-		}
-	}
-	if output, err := test.RunCommand(test.BinaryName, []string{"-E", test.Alias, certsRmCommandName, certsRmSubcommandName, certName}); err != nil {
-		t.Errorf("Error removing cert: %s - %s", err, output)
-		return
-	}
-}
 
-func TestCertsUpdateNoAssociation(t *testing.T) {
-	if err := test.ClearAssociations(); err != nil {
-		t.Error(err)
-		return
-	}
-	output, err := test.RunCommand(test.BinaryName, []string{certsUpdateCommandName, certsUpdateSubcommandName, certName, pubKeyPath, privKeyPath})
-	if err == nil {
-		t.Errorf("Expected error but no error returned: %s", output)
-		return
-	}
-	expectedOutput := "\033[31m\033[1m[fatal] \033[0mNo Datica environment has been associated. Run \"datica associate\" from a local git repo first\n"
-	if output != expectedOutput {
-		t.Errorf("Expected: %s. Found: %s", expectedOutput, output)
-		return
+		// test
+		err := CmdUpdate(data.hostname, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
 	}
 }

--- a/commands/clear/clear_test.go
+++ b/commands/clear/clear_test.go
@@ -3,119 +3,49 @@ package clear
 import (
 	"testing"
 
-	"github.com/daticahealth/cli/config"
-	"github.com/daticahealth/cli/models"
 	"github.com/daticahealth/cli/test"
 )
 
-const (
-	commandName    = "clear"
-	standardOutput = "All specified settings have been cleared\n"
-)
-
-var settings = models.Settings{
-	OrgID:          "org1234",
-	PrivateKeyPath: "",
-	SessionToken:   "1234",
-	UsersID:        "user1234",
-	Environments: map[string]models.AssociatedEnv{
-		"ctest": models.AssociatedEnv{
-			EnvironmentID: "env1234",
-			ServiceID:     "svc1234",
-			Directory:     "/dir",
-			Name:          "test",
-			Pod:           "air-force-pod",
-			OrgID:         "org1234",
-		},
-	},
-	Default: "ctest",
-	Pods: &[]models.Pod{
-		{
-			Name:                 "air-force-pod",
-			PHISafe:              true,
-			ImportRequiresLength: true,
-		},
-	},
-	PodCheck: 1478899890,
-}
-
 var clearTests = []struct {
-	env            string
-	privKey        bool
-	session        bool
-	envs           bool
-	defaultEnv     bool
-	pods           bool
-	all            bool
-	expectErr      bool
-	expectedOutput string
+	privKey    bool
+	session    bool
+	envs       bool
+	defaultEnv bool
+	pods       bool
 }{
-	{test.Alias, false, false, false, false, false, false, false, "No settings were specified. To see available options, run \"datica clear --help\"\n"},
-	{test.Alias, true, false, false, false, false, false, false, standardOutput},
-	{test.Alias, false, true, false, false, false, false, false, standardOutput},
-	{test.Alias, false, false, true, false, false, false, false, standardOutput},
-	{test.Alias, false, false, false, true, false, false, false, "\033[33m\033[1m[warning] \033[0mThe \"--default\" flag has been deprecated! It will be removed in a future version.\n" + standardOutput},
-	{test.Alias, false, false, false, false, true, false, false, standardOutput},
-	{test.Alias, false, false, false, false, false, true, false, "\033[33m\033[1m[warning] \033[0mThe \"--default\" flag has been deprecated! It will be removed in a future version.\n" + standardOutput},
-	{"bad-env", true, false, false, false, false, false, true, "\033[31m\033[1m[fatal] \033[0mNo environment named \"bad-env\" has been associated. Run \"datica associated\" to see what environments have been associated or run \"datica associate\" from a local git repo to create a new association\n"},
+	{false, false, false, false, false},
+	{false, false, false, false, true},
+	{false, false, false, true, false},
+	{false, false, true, false, false},
+	{false, true, false, false, false},
+	{true, false, false, false, false},
+	{true, true, true, true, true},
 }
 
 func TestClear(t *testing.T) {
 	for _, data := range clearTests {
 		t.Logf("Data: %+v", data)
-		if err := restoreSettings(); err != nil {
-			t.Error(err)
-			return
-		}
-		args := []string{"-E", data.env, commandName}
-		if data.privKey {
-			args = append(args, "--private-key")
-		}
-		if data.session {
-			args = append(args, "--session")
-		}
-		if data.envs {
-			args = append(args, "--environments")
-		}
-		if data.defaultEnv {
-			args = append(args, "--default")
-		}
-		if data.pods {
-			args = append(args, "--pods")
-		}
-		if data.all {
-			args = append(args, "--all")
-		}
-		output, err := test.RunCommand(test.BinaryName, args)
-		if err != nil != data.expectErr {
-			t.Errorf("Unexpected error: %s", output)
+		settings := test.GetSettings("")
+		err := CmdClear(data.privKey, data.session, data.envs, data.defaultEnv, data.pods, settings)
+		if err != nil {
+			t.Errorf("Unexpected error: %s", err)
 			continue
 		}
-		if output != data.expectedOutput {
-			t.Errorf("Expected: %s. Found: %s", data.expectedOutput, output)
+		if data.privKey && settings.PrivateKeyPath != "" {
+			t.Errorf("Private key should have been cleared")
 			continue
 		}
+		if data.session && settings.SessionToken != "" {
+			t.Errorf("Session token should have been cleared")
+		}
+		if data.envs && settings.Environments != nil && len(settings.Environments) != 0 {
+			t.Errorf("Environments should have been cleared")
+		}
+		if data.defaultEnv && settings.Default != "" {
+			t.Errorf("Default should have been cleared")
+		}
+		if data.pods && settings.Pods != nil && len(*settings.Pods) != 0 {
+			t.Errorf("Pods should have been cleared")
+		}
 	}
-}
-
-func TestClearNoAssociation(t *testing.T) {
-	if err := test.ClearAssociations(); err != nil {
-		t.Error(err)
-		return
-	}
-	output, err := test.RunCommand(test.BinaryName, []string{commandName, "--all"})
-	if err != nil {
-		t.Errorf("Unexpected error : %s - %s", err, output)
-		return
-	}
-	expectedOutput := "\033[33m\033[1m[warning] \033[0mThe \"--default\" flag has been deprecated! It will be removed in a future version.\n" + standardOutput
-	if output != expectedOutput {
-		t.Errorf("Expected: %s. Found: %s", expectedOutput, output)
-		return
-	}
-}
-
-func restoreSettings() error {
-	config.SaveSettings(&settings)
-	return nil
 }

--- a/commands/db/backup_test.go
+++ b/commands/db/backup_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+const (
+	dbName  = "database1"
+	dbID    = "d1"
+	dbJobID = "j1"
+)
+
+var dbBackupTests = []struct {
+	databaseName string
+	skipPoll     bool
+	expectErr    bool
+}{
+	{dbName, false, false},
+	{dbName, true, false},
+	{"invalid-svc", false, true},
+}
+
+func TestDbBackup(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	queriedJob := false
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"running","backup":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			queriedJob = true
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","status":"finished"}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/logs"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/logs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+
+	for _, data := range dbBackupTests {
+		t.Logf("Data: %+v", data)
+		queriedJob = false
+
+		// test
+		err := CmdBackup(data.databaseName, data.skipPoll, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
+
+		if !data.expectErr && data.skipPoll == queriedJob {
+			t.Errorf("The skip poll flag was not properly handled: skip? %t - job queried? %t", data.skipPoll, queriedJob)
+			continue
+		}
+	}
+}

--- a/commands/db/download_test.go
+++ b/commands/db/download_test.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+var downloadFilePath = "db-download.sql"
+
+var dbDownloadTests = []struct {
+	databaseName string
+	backupID     string
+	filePath     string
+	force        bool
+	expectErr    bool
+}{
+	{dbName, dbJobID, downloadFilePath, false, false},
+	{dbName, dbJobID, downloadFilePath, false, true}, // same filename without force fails
+	{dbName, dbJobID, downloadFilePath, true, false}, // same filename with force passes
+	{dbName, "invalid-job", downloadFilePath, true, true},
+	{"invalid-svc", dbJobID, downloadFilePath, true, true},
+}
+
+func TestDbDownload(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"finished","backup":{"key":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/backup"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+
+	for _, data := range dbDownloadTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdDownload(data.databaseName, data.backupID, data.filePath, data.force, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+
+		// assert
+		if err != nil {
+			if !data.expectErr {
+				t.Errorf("Unexpected error: %s", err)
+			}
+			continue
+		}
+
+		b, _ := ioutil.ReadFile(data.filePath)
+		if strings.TrimSpace(string(b)) != "test" {
+			t.Errorf("Unexpected file contents. Expected: test, actual: %s", string(b))
+		}
+	}
+	os.Remove(downloadFilePath)
+}

--- a/commands/db/export_test.go
+++ b/commands/db/export_test.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+var exportFilePath = "db-export.sql"
+
+var dbExportTests = []struct {
+	databaseName string
+	filePath     string
+	force        bool
+	expectErr    bool
+}{
+	{dbName, exportFilePath, false, false},
+	{dbName, exportFilePath, false, true}, // same filename without force fails
+	{dbName, exportFilePath, true, false}, // same filename with force passes
+	{"invalid-svc", exportFilePath, true, true},
+}
+
+func TestDbExport(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"running","backup":{"key":"0000000000000000000000000000000000000000000000000000000000000000","keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"finished","backup":{"key":"0000000000000000000000000000000000000000000000000000000000000000","keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/backup"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/backup"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/logs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+	mux.HandleFunc("/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+
+	for _, data := range dbExportTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdExport(data.databaseName, data.filePath, data.force, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+
+		// assert
+		if err != nil {
+			if !data.expectErr {
+				t.Errorf("Unexpected error: %s", err)
+			}
+			continue
+		}
+
+		b, _ := ioutil.ReadFile(data.filePath)
+		if strings.TrimSpace(string(b)) != "test" {
+			t.Errorf("Unexpected file contents. Expected: test, actual: %s", string(b))
+		}
+	}
+	os.Remove(exportFilePath)
+}

--- a/commands/db/import_test.go
+++ b/commands/db/import_test.go
@@ -1,0 +1,127 @@
+package db
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+var (
+	importFilePath = "db-import.sql"
+	dbImportID     = "j2"
+)
+
+var dbImportTests = []struct {
+	databaseName string
+	filePath     string
+	collection   string
+	database     string
+	skipBackup   bool
+	expectErr    bool
+}{
+	{dbName, importFilePath, "", "", false, false},
+	{dbName, importFilePath, "", "", true, false},
+	{dbName, "invalid-file", "", "", false, true},
+	{"invalid-svc", importFilePath, "", "", false, true},
+}
+
+func TestDbImport(t *testing.T) {
+	ioutil.WriteFile(importFilePath, []byte("select 1;"), 0644)
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	backedUp := false
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			backedUp = true
+			test.AssertEquals(t, r.Method, "POST")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"running","backup":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/import",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","type":"restore","status":"running","restore":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbImportID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"finished","backup":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbImportID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","type":"restore","status":"finished","restore":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbImportID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/logs"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbImportID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/logs"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/restore-url",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/restore"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/restore",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "PUT")
+			ioutil.ReadAll(r.Body)
+			r.Body.Close()
+			w.WriteHeader(200)
+		},
+	)
+	mux.HandleFunc("/logs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+
+	for _, data := range dbImportTests {
+		t.Logf("Data: %+v", data)
+		backedUp = false
+
+		// test
+		err := CmdImport(data.databaseName, data.filePath, data.collection, data.database, data.skipBackup, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+
+		// assert
+		if err != nil {
+			if !data.expectErr {
+				t.Errorf("Unexpected error: %s", err)
+			}
+			continue
+		}
+
+		if data.skipBackup == backedUp {
+			t.Errorf("The skip backup flag was not properly handled: skip? %t - backed up? %t", data.skipBackup, backedUp)
+			continue
+		}
+	}
+	os.Remove(importFilePath)
+}

--- a/commands/db/list_test.go
+++ b/commands/db/list_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+var dbListTests = []struct {
+	databaseName string
+	page         int
+	pageSize     int
+	expectErr    bool
+}{
+	{dbName, 1, 10, false},
+	{dbName, 2, 10, false},
+	{"invalid-svc", 1, 10, true},
+}
+
+func TestDbList(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"finished"}]`, dbJobID))
+		},
+	)
+
+	for _, data := range dbListTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdList(data.databaseName, data.page, data.pageSize, New(settings, crypto.New(), jobs.New(settings)), services.New(settings))
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
+	}
+}

--- a/commands/db/logs.go
+++ b/commands/db/logs.go
@@ -25,7 +25,7 @@ func CmdLogs(databaseName, backupID string, id IDb, is services.IServices, ij jo
 	if err != nil {
 		return err
 	}
-	return id.DumpLogs("backup", job, service)
+	return id.DumpLogs(job.Type, job, service)
 }
 
 // DumpLogs dumps logs from a Backup/Restore/Import/Export job to the console

--- a/commands/db/logs_test.go
+++ b/commands/db/logs_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/crypto"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/test"
+)
+
+var dbLogsTests = []struct {
+	databaseName string
+	jobID        string
+	expectErr    bool
+}{
+	{dbName, dbJobID, false},
+	{dbName, "invalid-job", true},
+	{dbName, dbImportID, true},
+	{"invalid-svc", dbJobID, true},
+}
+
+func TestDbLogs(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","type":"backup","status":"finished","backup":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbImportID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","type":"restore","status":"failed","restore":{"keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/logs"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/logs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+
+	for _, data := range dbLogsTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdLogs(data.databaseName, data.jobID, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+
+		// assert
+		if err != nil {
+			if !data.expectErr {
+				t.Errorf("Unexpected error: %s", err)
+			}
+			continue
+		}
+	}
+}

--- a/commands/services/contract.go
+++ b/commands/services/contract.go
@@ -96,7 +96,7 @@ var StopSubCmd = models.Command{
 	Name:      "stop",
 	ShortHelp: "Stop all instances of a given service (including all workers, rake tasks, and open consoles)",
 	LongHelp: "`services stop` shuts down all running instances of a given service. " +
-		"This is useful when performing maintenance on code services or other services without volumes and that service must be shutdown to perform that maintenance. " +
+		"This is useful when performing maintenance on code services or services without volumes that must be shutdown to perform that maintenance. " +
 		"Take caution when running this command as all instances of the service, all workers, all rake tasks, and all open console sessions will be stopped. " +
 		"Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_alias>\" services stop code-1\n```",

--- a/commands/services/contract.go
+++ b/commands/services/contract.go
@@ -31,7 +31,7 @@ var Cmd = models.Command{
 				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdServices(New(settings))
+				err := CmdServices(New(settings), volumes.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -57,7 +57,7 @@ var ListSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdServices(New(settings))
+				err := CmdServices(New(settings), volumes.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}

--- a/commands/services/contract.go
+++ b/commands/services/contract.go
@@ -6,6 +6,7 @@ import (
 	"github.com/daticahealth/cli/lib/auth"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/lib/prompts"
+	"github.com/daticahealth/cli/lib/volumes"
 	"github.com/daticahealth/cli/models"
 	"github.com/jault3/mow.cli"
 )
@@ -95,7 +96,7 @@ var StopSubCmd = models.Command{
 	Name:      "stop",
 	ShortHelp: "Stop all instances of a given service (including all workers, rake tasks, and open consoles)",
 	LongHelp: "`services stop` shuts down all running instances of a given service. " +
-		"This is useful when performing maintenance and a service must be shutdown to perform that maintenance. " +
+		"This is useful when performing maintenance on code services or other services without volumes and that service must be shutdown to perform that maintenance. " +
 		"Take caution when running this command as all instances of the service, all workers, all rake tasks, and all open console sessions will be stopped. " +
 		"Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_alias>\" services stop code-1\n```",
@@ -109,7 +110,7 @@ var StopSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdStop(*svcName, New(settings), jobs.New(settings), prompts.New())
+				err := CmdStop(*svcName, settings.Pod, New(settings), jobs.New(settings), volumes.New(settings), prompts.New())
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}

--- a/commands/services/contract.go
+++ b/commands/services/contract.go
@@ -96,7 +96,7 @@ var StopSubCmd = models.Command{
 	Name:      "stop",
 	ShortHelp: "Stop all instances of a given service (including all workers, rake tasks, and open consoles)",
 	LongHelp: "`services stop` shuts down all running instances of a given service. " +
-		"This is useful when performing maintenance on code services or services without volumes that must be shutdown to perform that maintenance. " +
+		"This is useful when performing maintenance on code services or services without volumes that must be shutdown to perform maintenance. " +
 		"Take caution when running this command as all instances of the service, all workers, all rake tasks, and all open console sessions will be stopped. " +
 		"Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_alias>\" services stop code-1\n```",

--- a/commands/services/list.go
+++ b/commands/services/list.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/lib/volumes"
 	"github.com/daticahealth/cli/models"
 	"github.com/olekukonko/tablewriter"
 )
 
 // CmdServices lists the names of all services for an environment.
-func CmdServices(is IServices) error {
+func CmdServices(is IServices, v volumes.IVolumes) error {
 	svcs, err := is.List()
+
 	if err != nil {
 		return err
 	}
@@ -18,9 +20,28 @@ func CmdServices(is IServices) error {
 		logrus.Println("No services found")
 		return nil
 	}
-	data := [][]string{{"NAME", "DNS", "RAM (GB)", "CPU", "STORAGE (GB)", "WORKER LIMIT"}}
+	data := [][]string{{"NAME", "DNS", "RAM (GB)", "CPU", "WORKER LIMIT", "SCALE", "STORAGE (GB)"}}
 	for _, s := range *svcs {
-		data = append(data, []string{s.Label, s.DNS, fmt.Sprintf("%d", s.Size.RAM), fmt.Sprintf("%d", s.Size.CPU), fmt.Sprintf("%d", s.Size.Storage), fmt.Sprintf("%d", s.WorkerScale)})
+
+		vols, err := v.List(s.ID)
+		if err != nil {
+			logrus.Errorf("Failed to retrieve volume information for service %s", s.Label)
+			logrus.Debugf("Volume information error for %s: %s", s.Label, err)
+		}
+		if vols == nil || len(*vols) == 0 {
+			vols = &[]models.Volume{{ID: 0, Type: "", Size: 0}}
+		}
+
+		volume := ""
+		for i, v := range *vols {
+			if i > 0 {
+				volume += ", "
+			}
+			volume += fmt.Sprintf("%d", v.Size)
+		}
+
+		data = append(data, []string{s.Label, s.DNS, fmt.Sprintf("%d", s.Size.RAM), fmt.Sprintf("%d", s.Size.CPU), fmt.Sprintf("%d", s.WorkerScale), fmt.Sprintf("%d", s.Scale), volume})
+
 	}
 
 	table := tablewriter.NewWriter(logrus.StandardLogger().Out)
@@ -30,6 +51,8 @@ func CmdServices(is IServices) error {
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("")
 	table.AppendBulk(data)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+
 	table.Render()
 	return nil
 }

--- a/commands/services/stop_test.go
+++ b/commands/services/stop_test.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/lib/volumes"
+	"github.com/daticahealth/cli/test"
+)
+
+var servicesStopTests = []struct {
+	svcName   string
+	pod       string
+	expectErr bool
+}{
+	{test.SvcLabel, test.Pod, false},
+	{test.SvcLabelAlt, test.Pod, true},
+	{"database-1", test.Pod, true},
+	{"invalid-svc-name", test.Pod, true},
+	{"database-2", "csb01", true},
+	{"database-2", test.Pod, true},
+}
+
+func TestServicesStop(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s","name":"code","redeployable":false},{"id":"%s","label":"%s","name":"code","redeployable":true},{"id":"%s","label":"database-1","name":"postgresql","redeployable":true},{"id":"%s","label":"database-2","name":"postgresql","redeployable":true}]`, test.SvcIDAlt, test.SvcLabelAlt, test.SvcID, test.SvcLabel, "3", "4"))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/jobs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, `[{"id":"1"}]`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/jobs/1",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "DELETE")
+			w.WriteHeader(204)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/volumes",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, `[]`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/4/volumes",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, `[{"id":"v","type":"simple","size":"20"}]`)
+		},
+	)
+
+	for _, data := range servicesStopTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdStop(data.svcName, data.pod, New(settings), jobs.New(settings), volumes.New(settings), &test.FakePrompts{})
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
+	}
+}

--- a/commands/status/status.go
+++ b/commands/status/status.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pmylund/sortutil"
 )
 
+const dateForm = "2006-01-02T15:04:05"
+
 func CmdStatus(envID string, is IStatus, ie environments.IEnvironments, iservices services.IServices) error {
 	env, err := ie.Retrieve(envID)
 	if err != nil {
@@ -36,7 +38,7 @@ func (s *SStatus) Status(env *models.Environment, services *[]models.Service) er
 
 	for _, service := range *services {
 		if service.Type != "" {
-			jobs, err := s.Jobs.RetrieveByStatus(service.ID, "running")
+			jobs, err := s.Jobs.List(service.ID, 1, 100)
 			if err != nil {
 				return err
 			}
@@ -57,12 +59,9 @@ func (s *SStatus) Status(env *models.Environment, services *[]models.Service) er
 						}
 					}
 				} else if len(service.ReleaseVersion) > 0 {
-					displayType = fmt.Sprintf("%s (%s)", service.Label, service.ReleaseVersion)
-				} else {
-					displayType = fmt.Sprintf("%s", service.Label)
+					displayType = fmt.Sprintf("%s (git:%s)", service.Label, service.ReleaseVersion)
 				}
 
-				const dateForm = "2006-01-02T15:04:05"
 				t, _ := time.Parse(dateForm, job.CreatedAt)
 				fmt.Fprintln(w, displayType+"\t"+job.Status+"\t"+t.Local().Format(time.Stamp))
 			}
@@ -75,10 +74,8 @@ func (s *SStatus) Status(env *models.Environment, services *[]models.Service) er
 					if latestBuildJob.ID == "" {
 						fmt.Fprintln(w, "--------"+"\t"+service.Label+"\t"+"-------"+"\t"+"---------------")
 					} else if latestBuildJob.ID != "" {
-						const dateForm = "2006-01-02T15:04:05"
 						t, _ := time.Parse(dateForm, latestBuildJob.CreatedAt)
-						displayType := service.Label
-						displayType = fmt.Sprintf("%s (%s)", displayType, latestBuildJob.Type)
+						displayType := fmt.Sprintf("%s (%s)", service.Label, latestBuildJob.Type)
 						fmt.Fprintln(w, displayType+"\t"+latestBuildJob.Status+"\t"+t.Local().Format(time.Stamp))
 					}
 				}

--- a/commands/worker/list.go
+++ b/commands/worker/list.go
@@ -45,7 +45,7 @@ func CmdList(svcName string, iw IWorker, is services.IServices, ij jobs.IJobs) e
 			workerJobs[j.Target] = &workerJob{0, 0}
 		}
 		if j.Status == "running" {
-			workerJobs[j.Target].running = 1
+			workerJobs[j.Target].running += 1
 		}
 	}
 

--- a/config/constants.go
+++ b/config/constants.go
@@ -11,7 +11,7 @@ const (
 	// VERSION is the current cli version
 	VERSION = "3.5.0"
 	// Beta determines whether or not this is a beta build of the CLI
-	Beta = true
+	Beta = false
 	// AccountsHost is the production accounts URL
 	AccountsHost = "https://product.datica.com/compliant-cloud"
 	// AuthHost is the production auth URL

--- a/config/constants.go
+++ b/config/constants.go
@@ -11,7 +11,7 @@ const (
 	// VERSION is the current cli version
 	VERSION = "3.4.2"
 	// Beta determines whether or not this is a beta build of the CLI
-	Beta = false
+	Beta = true
 	// AccountsHost is the production accounts URL
 	AccountsHost = "https://product.datica.com/compliant-cloud"
 	// AuthHost is the production auth URL

--- a/config/constants.go
+++ b/config/constants.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// VERSION is the current cli version
-	VERSION = "3.4.2"
+	VERSION = "3.5.0"
 	// Beta determines whether or not this is a beta build of the CLI
 	Beta = true
 	// AccountsHost is the production accounts URL

--- a/lib/volumes/contract.go
+++ b/lib/volumes/contract.go
@@ -1,0 +1,20 @@
+package volumes
+
+import "github.com/daticahealth/cli/models"
+
+// IVolumes
+type IVolumes interface {
+	List(svcID string) (*[]models.Volume, error)
+}
+
+// SVolumes is a concrete implementation of IVolumes
+type SVolumes struct {
+	Settings *models.Settings
+}
+
+// New returns an instance of IVolumes
+func New(settings *models.Settings) IVolumes {
+	return &SVolumes{
+		Settings: settings,
+	}
+}

--- a/lib/volumes/list.go
+++ b/lib/volumes/list.go
@@ -1,0 +1,21 @@
+package volumes
+
+import (
+	"fmt"
+
+	"github.com/daticahealth/cli/models"
+)
+
+func (v *SVolumes) List(svcID string) (*[]models.Volume, error) {
+	headers := v.Settings.HTTPManager.GetHeaders(v.Settings.SessionToken, v.Settings.Version, v.Settings.Pod, v.Settings.UsersID)
+	resp, statusCode, err := v.Settings.HTTPManager.Get(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/volumes", v.Settings.PaasHost, v.Settings.PaasHostVersion, v.Settings.EnvironmentID, svcID), headers)
+	if err != nil {
+		return nil, err
+	}
+	var volumes []models.Volume
+	err = v.Settings.HTTPManager.ConvertResp(resp, statusCode, &volumes)
+	if err != nil {
+		return nil, err
+	}
+	return &volumes, nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -329,6 +329,12 @@ type UserKey struct {
 	Key  string `json:"key"`
 }
 
+type Volume struct {
+	ID   int    `json:"id"`
+	Type string `json:"type"`
+	Size int    `json:"size"`
+}
+
 type Workers struct {
 	Limit   int            `json:"worker_limit,omitempty"`
 	Workers map[string]int `json:"workers"`

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,8 +1,0 @@
-package test
-
-const (
-	BinaryName = "cli"
-	EnvLabel   = "cli-integration-tests"
-	SvcLabel   = "code-1"
-	Alias      = "ctest"
-)

--- a/test/util.go
+++ b/test/util.go
@@ -1,45 +1,101 @@
 package test
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/daticahealth/cli/lib/httpclient"
+	"github.com/daticahealth/cli/models"
 )
 
-// SetUpGitRepo runs git init in the current directory.
-func SetUpGitRepo() error {
-	output, err := RunCommand("git", []string{"init"})
-	if err != nil {
-		return fmt.Errorf("Unexpected error setting up git repo: %s", output)
-	}
-	return nil
+const (
+	Alias     = "1"
+	EnvID     = "env1"
+	EnvName   = "cli-tests1"
+	Namespace = "namespace1"
+	OrgID     = "org1"
+	Pod       = "pod1"
+	SvcID     = "svc1"
+	SvcLabel  = "code1"
+
+	AliasAlt     = "2"
+	EnvIDAlt     = "env2"
+	EnvNameAlt   = "cli-tests2"
+	NamespaceAlt = "namespace2"
+	OrgIDAlt     = "org2"
+	PodAlt       = "pod2"
+	SvcIDAlt     = "svc2"
+	SvcLabelAlt  = "code2"
+)
+
+func Setup() (*http.ServeMux, *httptest.Server, *url.URL) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+
+	baseURL, _ := url.Parse(server.URL)
+	return mux, server, baseURL
 }
 
-// SetUpAssociation runs the associate command with the appropriate arguments to
-// successfully associate to the test environment.
-func SetUpAssociation() error {
-	output, err := RunCommand(BinaryName, []string{"associate", EnvLabel, SvcLabel, "-a", Alias})
-	if err != nil {
-		return fmt.Errorf("Unexpected error setting up association: %s", output)
-	}
-	return nil
+func Teardown(server *httptest.Server) {
+	server.Close()
 }
 
-// ClearAssociations runs the clear --environments command.
-func ClearAssociations() error {
-	output, err := RunCommand(BinaryName, []string{"clear", "--environments"})
-	if err != nil {
-		return fmt.Errorf("Unexpected error clearing associations: %s", output)
+func AssertEquals(t *testing.T, expected, actual string) {
+	if expected != actual {
+		t.Errorf("Expected: %s, actual: %s", expected, actual)
 	}
-	return nil
 }
 
-// RunCommand runs the given command and arguments with the current os ENV.
-func RunCommand(command string, args []string) (string, error) {
-	cmd := exec.Command(command, args...)
-	cmd.Env = os.Environ()
-	cmd.Stdin = strings.NewReader("n\n")
-	output, err := cmd.CombinedOutput()
-	return string(output), err
+func GetSettings(baseURL string) *models.Settings {
+	return &models.Settings{
+		SessionToken:   "token",
+		PrivateKeyPath: "ssh_rsa",
+		Default:        EnvName,
+		HTTPManager:    httpclient.NewTLSHTTPManager(false),
+		PaasHost:       baseURL,
+		Environments: map[string]models.AssociatedEnv{
+			Alias: models.AssociatedEnv{
+				Name:          EnvName,
+				EnvironmentID: EnvID,
+				ServiceID:     SvcID,
+				Directory:     "/",
+				Pod:           Pod,
+				OrgID:         OrgID,
+			},
+		},
+		OrgID:         OrgID,
+		EnvironmentID: EnvID,
+		ServiceID:     SvcID,
+		Pods: &[]models.Pod{
+			models.Pod{
+				Name: Pod,
+			},
+			models.Pod{
+				Name: PodAlt,
+			},
+		},
+	}
+}
+
+type FakePrompts struct{}
+
+func (f *FakePrompts) UsernamePassword() (string, string, error) {
+	return "username", "password", nil
+}
+func (f *FakePrompts) KeyPassphrase(string) string {
+	return "passphrase"
+}
+func (f *FakePrompts) Password(msg string) string {
+	return "password"
+}
+func (f *FakePrompts) PHI() error {
+	return nil
+}
+func (f *FakePrompts) YesNo(msg string) error {
+	return nil
+}
+func (f *FakePrompts) OTP(string) string {
+	return "123456"
 }


### PR DESCRIPTION
* fixed storage size in `services list`
* show the service scale in `services list`
* disallow stopping a service with a data volume
* `status` command outputs a wider variety of job states
* fixed the running worker count displayed in `workers list`