### PR TITLE
BUG: Datica CLI does not save successful auth on certain command failures

### DIFF
--- a/lib/auth/signin.go
+++ b/lib/auth/signin.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/daticahealth/cli/config"
 	"github.com/daticahealth/cli/models"
 )
 
@@ -45,6 +46,9 @@ func (a *SAuth) Signin() (*models.User, error) {
 	a.Settings.UsersID = user.UsersID
 	a.Settings.Username = user.Username
 	a.Settings.SessionToken = user.SessionToken
+
+	config.SaveSettings(a.Settings)
+
 	return user, nil
 }
 


### PR DESCRIPTION
Specifically, if the app receives an OS signal after it authenticates but before the command can finish or if the secondary command uses `return fmt.Errorf()`, the hook to save settings: `app.After` does not get run.

This change fixes it to save the successful authentication right after it's received.

I feel like this is safe, due to authentication happening first (or should be) before any other settings are written to.

The current sequence appears to be:
1. Load settings if exists
2. Check for auth
3. Sign in
4. Perform Command
5. Save settings

Changed to:
1. Load settings if exists
2. Check for auth
3. Sign in
4. Save settings
5. Perform Command
6. Save settings

Demonstrated by following session (no real info or guids):
```
 ✘ jake cli (bug/settings-not-saving) $ ./main -E 'my-fake-env' console app01 'bundle exec rails c'
Username or Email: my.test.email@email.com
Password: 
This account has two-factor authentication enabled.
Your authenticator one-time password: 000000
Opening console to code (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)
[fatal] (92001) Console Command Not Authorized: The command supplied is not a whitelisted command.
 ✘ jake cli (bug/settings-not-saving) $ ./main -E 'my-fake-env' console app01 'bundle exec rails c'
Opening console to code (XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)
[fatal] (92001) Console Command Not Authorized: The command supplied is not a whitelisted command.
```