### PR TITLE
Acl group support

### DIFF
--- a/commands/invites/contract.go
+++ b/commands/invites/contract.go
@@ -114,14 +114,15 @@ var SendSubCmd = models.Command{
 	Name:      "send",
 	ShortHelp: "Send an invite to a user by email for a given organization",
 	LongHelp: "`invites send` invites a new user to your environment's organization. " +
-		"The requires pieces of information are the email address to send the invitation to and the group to which to invite them. " +
+		"The only piece of information required is the email address to send the invitation to. " +
+		"The invited user will join the organization as a member with no permissions. " +
+		"You must grant them permission through the dashboard. " +
 		"The recipient does **not** need to have a Dashboard account in order to send them an invitation. " +
 		"However, they will need to have a Dashboard account to accept the invitation. Here is a sample command\n\n" +
-		"```\ndatica -E \"<your_env_alias>\" invites send coworker@datica.com support\n```",
+		"```\ndatica -E \"<your_env_alias>\" invites send coworker@datica.com\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
 			email := subCmd.StringArg("EMAIL", "", "The email of a user to invite to the associated environment. This user does not need to have a Datica account prior to sending the invitation")
-			group := subCmd.StringArg("GROUP", "", "The group to which the user will be invited")
 			subCmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -129,12 +130,12 @@ var SendSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(true, true, settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdSend(*email, settings.EnvironmentName, *group, New(settings), prompts.New())
+				err := CmdSend(*email, settings.EnvironmentName, New(settings), prompts.New())
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
 			}
-			subCmd.Spec = "EMAIL GROUP"
+			subCmd.Spec = "EMAIL"
 		}
 	},
 }
@@ -144,7 +145,7 @@ type IInvites interface {
 	Accept(inviteCode string) (string, error)
 	List() (*[]models.Invite, error)
 	Rm(inviteID string) error
-	Send(email string, group string) error
+	Send(email string) error
 	ListOrgGroups() (*[]models.Group, error)
 }
 

--- a/commands/invites/list.go
+++ b/commands/invites/list.go
@@ -38,17 +38,17 @@ func (i *SInvites) List() (*[]models.Invite, error) {
 	return &invites, nil
 }
 
-// ListRoles lists all available roles
-func (i *SInvites) ListRoles() (*[]models.Role, error) {
+// ListOrgGroups lists all available groups for an organization
+func (i *SInvites) ListOrgGroups() (*[]models.Group, error) {
 	headers := i.Settings.HTTPManager.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
-	resp, statusCode, err := i.Settings.HTTPManager.Get(nil, fmt.Sprintf("%s%s/orgs/roles", i.Settings.AuthHost, i.Settings.AuthHostVersion), headers)
+	resp, statusCode, err := i.Settings.HTTPManager.Get(nil, fmt.Sprintf("%s%s/acls/%s/groups", i.Settings.AuthHost, i.Settings.AuthHostVersion, i.Settings.OrgID), headers)
 	if err != nil {
 		return nil, err
 	}
-	var roles []models.Role
-	err = i.Settings.HTTPManager.ConvertResp(resp, statusCode, &roles)
+	var groupWrapper models.GroupWrapper
+	err = i.Settings.HTTPManager.ConvertResp(resp, statusCode, &groupWrapper)
 	if err != nil {
 		return nil, err
 	}
-	return &roles, nil
+	return groupWrapper.Groups, nil
 }

--- a/commands/invites/list.go
+++ b/commands/invites/list.go
@@ -38,7 +38,7 @@ func (i *SInvites) List() (*[]models.Invite, error) {
 	return &invites, nil
 }
 
-// ListOrgGroups lists all available groups for an organization
+// ListOrgGroups lists all available groups for an organization and their members
 func (i *SInvites) ListOrgGroups() (*[]models.Group, error) {
 	headers := i.Settings.HTTPManager.GetHeaders(i.Settings.SessionToken, i.Settings.Version, i.Settings.Pod, i.Settings.UsersID)
 	resp, statusCode, err := i.Settings.HTTPManager.Get(nil, fmt.Sprintf("%s%s/acls/%s/groups", i.Settings.AuthHost, i.Settings.AuthHostVersion, i.Settings.OrgID), headers)

--- a/commands/invites/send.go
+++ b/commands/invites/send.go
@@ -3,33 +3,18 @@ package invites
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/daticahealth/cli/lib/prompts"
 	"github.com/daticahealth/cli/models"
 )
 
-func CmdSend(email, envName, groupName string, ii IInvites, ip prompts.IPrompts) error {
+func CmdSend(email string, envName string, ii IInvites, ip prompts.IPrompts) error {
 	err := ip.YesNo(fmt.Sprintf("Are you sure you want to invite %s to your %s organization? (y/n) ", email, envName))
 	if err != nil {
 		return err
 	}
-	groups, err := ii.ListOrgGroups()
-	if err != nil {
-		return err
-	}
-	group := ""
-	for _, g := range *groups {
-		if strings.ToLower(g.Name) == strings.ToLower(groupName) {
-			group = g.Name
-			break
-		}
-	}
-	if group == "" {
-		return fmt.Errorf("Error: Organization does not contain group %s", groupName)
-	}
-	err = ii.Send(email, group)
+	err = ii.Send(email)
 	if err != nil {
 		return err
 	}
@@ -40,10 +25,10 @@ func CmdSend(email, envName, groupName string, ii IInvites, ip prompts.IPrompts)
 // Send invites a user by email to the associated environment. They do
 // not need a Dashboard account prior to inviting them, but they must have a
 // Dashboard account in order to accept the invitation.
-func (i *SInvites) Send(email string, group string) error {
+func (i *SInvites) Send(email string) error {
 	inv := models.PostInvite{
 		Email:        email,
-		Group:        group,
+		Role:         5,
 		LinkTemplate: fmt.Sprintf("%s/accept-invite?code={inviteCode}", i.Settings.AccountsHost),
 	}
 	b, err := json.Marshal(inv)

--- a/commands/users/list.go
+++ b/commands/users/list.go
@@ -24,11 +24,7 @@ func CmdList(myUsersID string, iu IUsers, ii invites.IInvites) error {
 	for _, group := range *orgGroups {
 		groupMembers := group.Members
 		for _, member := range *groupMembers {
-			if _, ok := members[member.Email]; ok {
-				members[member.Email] = append(members[member.Email], group.Name)
-			} else {
-				members[member.Email] = []string{group.Name}
-			}
+			members[member.Email] = append(members[member.Email], group.Name)
 		}
 	}
 	for k, v := range members {

--- a/commands/users/list.go
+++ b/commands/users/list.go
@@ -7,38 +7,28 @@ import (
 	"github.com/daticahealth/cli/commands/invites"
 	"github.com/daticahealth/cli/models"
 	"github.com/olekukonko/tablewriter"
-	"github.com/pmylund/sortutil"
 )
 
 func CmdList(myUsersID string, iu IUsers, ii invites.IInvites) error {
-	orgUsers, err := iu.List()
+	orgGroups, err := ii.ListOrgGroups()
 	if err != nil {
 		return err
 	}
-	if orgUsers == nil || len(*orgUsers) == 0 {
+	if orgGroups == nil || len(*orgGroups) == 0 {
 		logrus.Println("No users found")
 		return nil
 	}
-	roles, err := ii.ListRoles()
-	if err != nil {
-		return err
-	}
-	rolesMap := map[int]string{}
-	for _, r := range *roles {
-		rolesMap[r.ID] = r.Name
-	}
-
-	sortutil.DescByField(*orgUsers, "RoleID")
-
-	data := [][]string{{"EMAIL", "ROLE"}}
-	for _, user := range *orgUsers {
-		if user.ID == myUsersID {
-			data = append(data, []string{user.Email, fmt.Sprintf("%s (you)", rolesMap[user.RoleID])})
-		} else {
-			data = append(data, []string{user.Email, rolesMap[user.RoleID]})
+	data := [][]string{{"EMAIL", "GROUP(S)"}}
+	for _, group := range *orgGroups {
+		groupMembers := group.Members
+		for _, member := range *groupMembers {
+			if member.ID == myUsersID {
+				data = append(data, []string{member.Email, fmt.Sprintf("%s (you)", group.Name)})
+			} else {
+				data = append(data, []string{member.Email, group.Name})
+			}
 		}
 	}
-
 	table := tablewriter.NewWriter(logrus.StandardLogger().Out)
 	table.SetBorder(false)
 	table.SetRowLine(false)

--- a/commands/users/list.go
+++ b/commands/users/list.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/daticahealth/cli/commands/invites"
@@ -19,15 +20,19 @@ func CmdList(myUsersID string, iu IUsers, ii invites.IInvites) error {
 		return nil
 	}
 	data := [][]string{{"EMAIL", "GROUP(S)"}}
+	members := make(map[string][]string)
 	for _, group := range *orgGroups {
 		groupMembers := group.Members
 		for _, member := range *groupMembers {
-			if member.ID == myUsersID {
-				data = append(data, []string{member.Email, fmt.Sprintf("%s (you)", group.Name)})
+			if _, ok := members[member.Email]; ok {
+				members[member.Email] = append(members[member.Email], group.Name)
 			} else {
-				data = append(data, []string{member.Email, group.Name})
+				members[member.Email] = []string{group.Name}
 			}
 		}
+	}
+	for k, v := range members {
+		data = append(data, []string{k, strings.Join(v, ", ")})
 	}
 	table := tablewriter.NewWriter(logrus.StandardLogger().Out)
 	table.SetBorder(false)

--- a/models/models.go
+++ b/models/models.go
@@ -81,7 +81,7 @@ type GroupWrapper struct {
 type Group struct {
 	Name      string         `json:"name"`
 	Acls      []string       `json:"acls"`
-	Protected bool           `json:protected`
+	Protected bool           `json:"protected"`
 	Members   *[]GroupMember `json:"members"`
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -110,13 +110,13 @@ type HTTPManager interface {
 
 // Invite represents an invitation to an organization
 type Invite struct {
-	ID       string   `json:"id"`
-	OrgID    string   `json:"orgID"`
-	SenderID string   `json:"senderID"`
-	Groups   []string `json:"groups"`
-	Email    string   `json:"email"`
-	Consumed bool     `json:"consumed"`
-	Revoked  bool     `json:"revoked"`
+	ID       string `json:"id"`
+	OrgID    string `json:"orgID"`
+	SenderID string `json:"senderID"`
+	RoleID   int    `json:"roleID"`
+	Email    string `json:"email"`
+	Consumed bool   `json:"consumed"`
+	Revoked  bool   `json:"revoked"`
 }
 
 // LogHits contain ordering data for logs
@@ -225,7 +225,7 @@ type PodWrapper struct {
 
 type PostInvite struct {
 	Email        string `json:"email"`
-	Group        string `json:"group"`
+	Role         int    `json:"role"`
 	LinkTemplate string `json:"linkTemplate"`
 }
 

--- a/models/models.go
+++ b/models/models.go
@@ -73,6 +73,23 @@ type Error struct {
 	Code        int    `json:"code"`
 }
 
+// ACL support
+type GroupWrapper struct {
+	Groups *[]Group `json:"groups"`
+}
+
+type Group struct {
+	Name      string         `json:"name"`
+	Acls      []string       `json:"acls"`
+	Protected bool           `json:protected`
+	Members   *[]GroupMember `json:"members"`
+}
+
+type GroupMember struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}
+
 // Hits contain arrays of log data
 type Hits struct {
 	Total    int64      `json:"total"`
@@ -93,13 +110,13 @@ type HTTPManager interface {
 
 // Invite represents an invitation to an organization
 type Invite struct {
-	ID       string `json:"id"`
-	OrgID    string `json:"orgID"`
-	SenderID string `json:"senderID"`
-	RoleID   int    `json:"roleID"`
-	Email    string `json:"email"`
-	Consumed bool   `json:"consumed"`
-	Revoked  bool   `json:"revoked"`
+	ID       string   `json:"id"`
+	OrgID    string   `json:"orgID"`
+	SenderID string   `json:"senderID"`
+	Groups   []string `json:"groups"`
+	Email    string   `json:"email"`
+	Consumed bool     `json:"consumed"`
+	Revoked  bool     `json:"revoked"`
 }
 
 // LogHits contain ordering data for logs
@@ -208,7 +225,7 @@ type PodWrapper struct {
 
 type PostInvite struct {
 	Email        string `json:"email"`
-	Role         int    `json:"role"`
+	Group        string `json:"group"`
 	LinkTemplate string `json:"linkTemplate"`
 }
 


### PR DESCRIPTION
This PR updates the `invites send` command to not accept a `role` and updates the `users list` command to list users and the groups they belong to.