### PR TITLE
Long help location

### DIFF
--- a/datica/datica.go
+++ b/datica/datica.go
@@ -85,9 +85,8 @@ func Run() {
 		}
 	}
 
-	var app = cli.App("datica", fmt.Sprintf("Datica CLI. Version %s", config.VERSION))
-	app.LongDesc = "\nA lot has changed in the new Datica CLI! Check out our new CLI guide to see what has changed https://resources.datica.com/compliant-cloud/guides/cli-v4"
-	app.LongDescLocation = cli.DescriptionLocationBottom
+	var app = cli.App("datica", fmt.Sprintf("Datica CLI version %s. A lot has changed in the new Datica CLI! Check out our new CLI guide to see what has changed https://resources.datica.com/compliant-cloud/guides/cli-v4", config.VERSION))
+	app.DescLocation = cli.DescriptionLocationBottom
 	settings := &models.Settings{}
 	InitGlobalOpts(app, settings)
 	InitCLI(app, settings)

--- a/datica/datica.go
+++ b/datica/datica.go
@@ -86,6 +86,8 @@ func Run() {
 	}
 
 	var app = cli.App("datica", fmt.Sprintf("Datica CLI. Version %s", config.VERSION))
+	app.LongDesc = "\nA lot has changed in the new Datica CLI! Check out our new CLI guide to see what has changed https://resources.datica.com/compliant-cloud/guides/cli-v4"
+	app.LongDescLocation = cli.DescriptionLocationBottom
 	settings := &models.Settings{}
 	InitGlobalOpts(app, settings)
 	InitCLI(app, settings)

--- a/vendor/github.com/jault3/mow.cli/commands.go
+++ b/vendor/github.com/jault3/mow.cli/commands.go
@@ -352,12 +352,11 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 	fmt.Fprint(writer, "\n\n")
 
 	cmdDesc := c.desc
-	cmdDescLoc := 0
+	cmdDescLoc := c.LongDescLocation
 	if longDesc && len(c.LongDesc) > 0 {
 		cmdDesc = c.LongDesc
-		cmdDescLoc = 1
 	}
-	if len(cmdDesc) > 0 && cmdDescLoc == 0 {
+	if len(cmdDesc) > 0 && cmdDescLoc == DescriptionLocationTop {
 		fmt.Fprintf(writer, "%s\n", cmdDesc)
 	}
 
@@ -399,7 +398,7 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 		fmt.Fprintf(writer, "\nRun '%s COMMAND --help' for more information on a command.\n", path)
 	}
 
-	if len(cmdDesc) > 0 && cmdDescLoc == 1 {
+	if len(cmdDesc) > 0 && cmdDescLoc == DescriptionLocationBottom {
 		fmt.Fprintf(writer, "%s\n", cmdDesc)
 	}
 }

--- a/vendor/github.com/jault3/mow.cli/commands.go
+++ b/vendor/github.com/jault3/mow.cli/commands.go
@@ -35,8 +35,8 @@ type Cmd struct {
 	Spec string
 	// The command long description to be shown when help is requested
 	LongDesc string
-	// Location of the LongDesc text. 0 for the top or 1 for bottom of the full output
-	LongDescLocation DescriptionLocation
+	// Location of the description text. 0 for the top or 1 for bottom of the full output
+	DescLocation DescriptionLocation
 	// The command error handling strategy
 	ErrorHandling flag.ErrorHandling
 
@@ -352,7 +352,7 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 	fmt.Fprint(writer, "\n\n")
 
 	cmdDesc := c.desc
-	cmdDescLoc := c.LongDescLocation
+	cmdDescLoc := c.DescLocation
 	if longDesc && len(c.LongDesc) > 0 {
 		cmdDesc = c.LongDesc
 	}
@@ -399,7 +399,7 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 	}
 
 	if len(cmdDesc) > 0 && cmdDescLoc == DescriptionLocationBottom {
-		fmt.Fprintf(writer, "%s\n", cmdDesc)
+		fmt.Fprintf(writer, "\n%s\n", cmdDesc)
 	}
 }
 

--- a/vendor/github.com/jault3/mow.cli/commands.go
+++ b/vendor/github.com/jault3/mow.cli/commands.go
@@ -9,6 +9,16 @@ import (
 	"text/tabwriter"
 )
 
+// DescriptionLocation defines where to print out help text
+type DescriptionLocation int
+
+const (
+	// DescriptionLocationTop specifies printing out the help text at the top of the output
+	DescriptionLocationTop DescriptionLocation = iota
+	// DescriptionLocationBottom specifies printing out the help text at the bottom of the output
+	DescriptionLocationBottom
+)
+
 /*
 Cmd represents a command (or sub command) in a CLI application. It should be constructed
 by calling Command() on an app to create a top level command or by calling Command() on another
@@ -25,6 +35,8 @@ type Cmd struct {
 	Spec string
 	// The command long description to be shown when help is requested
 	LongDesc string
+	// Location of the LongDesc text. 0 for the top or 1 for bottom of the full output
+	LongDescLocation DescriptionLocation
 	// The command error handling strategy
 	ErrorHandling flag.ErrorHandling
 
@@ -339,12 +351,14 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 	}
 	fmt.Fprint(writer, "\n\n")
 
-	desc := c.desc
+	cmdDesc := c.desc
+	cmdDescLoc := 0
 	if longDesc && len(c.LongDesc) > 0 {
-		desc = c.LongDesc
+		cmdDesc = c.LongDesc
+		cmdDescLoc = 1
 	}
-	if len(desc) > 0 {
-		fmt.Fprintf(writer, "%s\n", desc)
+	if len(cmdDesc) > 0 && cmdDescLoc == 0 {
+		fmt.Fprintf(writer, "%s\n", cmdDesc)
 	}
 
 	w := tabwriter.NewWriter(writer, 15, 1, 3, ' ', 0)
@@ -383,6 +397,10 @@ func (c *Cmd) PrintLongHelpTo(longDesc bool, writer io.Writer) {
 
 	if len(c.Commands) > 0 {
 		fmt.Fprintf(writer, "\nRun '%s COMMAND --help' for more information on a command.\n", path)
+	}
+
+	if len(cmdDesc) > 0 && cmdDescLoc == 1 {
+		fmt.Fprintf(writer, "%s\n", cmdDesc)
 	}
 }
 


### PR DESCRIPTION
This adds a long description to the CLI application itself and moves it to the bottom to be more visible. This will help alleviate questions when running commands that have been removed in the newest version.