### PR TITLE
Let's Encrypt support

### DIFF
--- a/commands/certs/contract.go
+++ b/commands/certs/contract.go
@@ -29,16 +29,19 @@ var Cmd = models.Command{
 
 var CreateSubCmd = models.Command{
 	Name:      "create",
-	ShortHelp: "Create a new domain with an SSL certificate and private key",
+	ShortHelp: "Create a new domain with an SSL certificate and private key or create a Let's Encrypt certificate",
 	LongHelp: "`certs create` allows you to upload an SSL certificate and private key which can be used to secure your public facing code service. " +
+		"Alternatively, you may opt to create a Let's Encrypt certificate. When creating a Let's Encrypt certificate, you only need to provide the certificate name along with the \"-l\" flag. " +
+		"Let's Encrypt certificates are issued asynchronously and may not be available immediately. Use the [certs list](#certs-list) command to check on the issuance status. " +
+		"Once issued, Let's Encrypt certificates automatically renew before expiring. " +
 		"Cert creation can be done at any time, even after environment provisioning, but must be done before [creating a site](#sites-create). " +
-		"When creating a cert, the CLI will check to ensure the certificate and private key match. If you are using a self signed cert, pass in the `-s` flag and the hostname check will be skipped. " +
+		"When uploading a custom cert, the CLI will check to ensure the certificate and private key match. If you are using a self signed cert, pass in the `-s` flag and the hostname check will be skipped. " +
 		"Datica requires that your certificate include your own certificate, intermediate certificates, and the root certificate in that order. " +
 		"If you only include your certificate, the CLI will attempt to resolve this and fetch intermediate and root certificates for you. " +
 		"It is advised that you create a full chain before running this command as the `-r` flag is accomplished on a \"best effort\" basis.\n\n" +
-		"The `HOSTNAME` for a certificate does not need to match the valid Subject of the actual SSL certificate nor does it need to match the `site` name used in the `sites create` command. " +
-		"The `HOSTNAME` is used for organizational purposes only and can be named anything with the exclusion of the following characters: `/`, `&`, `%`. Here is a sample command\n\n" +
-		"```\ndatica -E \"<your_env_name>\" certs create wildcard_mysitecom ~/path/to/cert.pem ~/path/to/priv.key\n```",
+		"Here are a few sample commands\n\n" +
+		"```\ndatica -E \"<your_env_name>\" certs create wildcard_mysitecom ~/path/to/cert.pem ~/path/to/priv.key\n" +
+		"datica -E \"<your_env_name>\" certs create my.site.com --lets-encrypt\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
 			name := subCmd.StringArg("NAME", "", "The name of this SSL certificate plus private key pair")
@@ -46,6 +49,7 @@ var CreateSubCmd = models.Command{
 			privKeyPath := subCmd.StringArg("PRIVATE_KEY_PATH", "", "The path to an unencrypted private key file in PEM format")
 			selfSigned := subCmd.BoolOpt("s self-signed", false, "Whether or not the given SSL certificate and private key are self signed")
 			resolve := subCmd.BoolOpt("r resolve", true, "Whether or not to attempt to automatically resolve incomplete SSL certificate issues")
+			letsEncrypt := subCmd.BoolOpt("l lets-encrypt", false, "Whether or not this is a Let's Encrypt certificate")
 			subCmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -53,12 +57,12 @@ var CreateSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdCreate(*name, *pubKeyPath, *privKeyPath, *selfSigned, *resolve, New(settings), services.New(settings), ssl.New(settings))
+				err := CmdCreate(*name, *pubKeyPath, *privKeyPath, *selfSigned, *resolve, *letsEncrypt, New(settings), services.New(settings), ssl.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
 			}
-			subCmd.Spec = "NAME PUBLIC_KEY_PATH PRIVATE_KEY_PATH [-s] [-r]"
+			subCmd.Spec = "NAME ((PUBLIC_KEY_PATH PRIVATE_KEY_PATH [-s] [-r]) | -l)"
 		}
 	},
 }
@@ -67,7 +71,9 @@ var ListSubCmd = models.Command{
 	Name:      "list",
 	ShortHelp: "List all existing domains that have SSL certificate and private key pairs",
 	LongHelp: "`certs list` lists all of the available certs you have created on your environment. " +
-		"The displayed names are the names that should be used as the `CERT_NAME` parameter in the [sites create](#sites-create) command. Here is a sample command\n\n" +
+		"The displayed names are the names that should be used as the `CERT_NAME` parameter in the [sites create](#sites-create) command. " +
+		"If any certs are Let's Encrypt certs, the issuance status will also be shown. " +
+		"Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_name>\" certs list\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
@@ -117,6 +123,7 @@ var UpdateSubCmd = models.Command{
 	ShortHelp: "Update the SSL certificate and private key pair for an existing domain",
 	LongHelp: "`certs update` works nearly identical to the [certs create](#certs-create) command. " +
 		"All rules regarding self signed certs and certificate resolution from the `certs create` command apply to the `certs update` command. " +
+		"Let's Encrypt certs cannot be updated since they are automatically renewed before expiring. " +
 		"This is useful for when your certificates have expired and you need to upload new ones. Update your certs and then redeploy your service_proxy. Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_name>\" certs update mywebsite.com ~/path/to/new/cert.pem ~/path/to/new/priv.key\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {

--- a/commands/certs/contract.go
+++ b/commands/certs/contract.go
@@ -67,7 +67,7 @@ var ListSubCmd = models.Command{
 	Name:      "list",
 	ShortHelp: "List all existing domains that have SSL certificate and private key pairs",
 	LongHelp: "`certs list` lists all of the available certs you have created on your environment. " +
-		"The displayed names are the names that should be used as the `DOMAIN` parameter in the [sites create](#sites-create) command. Here is a sample command\n\n" +
+		"The displayed names are the names that should be used as the `CERT_NAME` parameter in the [sites create](#sites-create) command. Here is a sample command\n\n" +
 		"```\ndatica -E \"<your_env_name>\" certs list\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
@@ -94,7 +94,7 @@ var RmSubCmd = models.Command{
 		"```\ndatica -E \"<your_env_name>\" certs rm mywebsite.com\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
-			name := subCmd.StringArg("HOSTNAME", "", "The hostname of the domain and SSL certificate and private key pair")
+			name := subCmd.StringArg("NAME", "", "The name of the certificate to remove")
 			subCmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -107,7 +107,7 @@ var RmSubCmd = models.Command{
 					logrus.Fatal(err.Error())
 				}
 			}
-			subCmd.Spec = "HOSTNAME"
+			subCmd.Spec = "NAME"
 		}
 	},
 }
@@ -145,10 +145,11 @@ var UpdateSubCmd = models.Command{
 
 // ICerts
 type ICerts interface {
-	Create(hostname, pubKey, privKey, svcID string) error
-	Update(hostname, pubKey, privKey, svcID string) error
+	Create(name, pubKey, privKey, svcID string) error
+	CreateLetsEncrypt(name, svcID string) error
+	Update(name, pubKey, privKey, svcID string) error
 	List(svcID string) (*[]models.Cert, error)
-	Rm(hostname, svcID string) error
+	Rm(name, svcID string) error
 }
 
 // SCerts is a concrete implementation of ICerts

--- a/commands/certs/create.go
+++ b/commands/certs/create.go
@@ -14,9 +14,9 @@ import (
 	"github.com/daticahealth/cli/models"
 )
 
-func CmdCreate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
-	if strings.ContainsAny(hostname, config.InvalidChars) {
-		return fmt.Errorf("Invalid cert hostname. Hostnames must not contain the following characters: %s", config.InvalidChars)
+func CmdCreate(name, pubKeyPath, privKeyPath string, selfSigned, resolve bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid cert name. Names must not contain the following characters: %s", config.InvalidChars)
 	}
 	if _, err := os.Stat(pubKeyPath); os.IsNotExist(err) {
 		return fmt.Errorf("A cert does not exist at path '%s'", pubKeyPath)
@@ -24,7 +24,7 @@ func CmdCreate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve boo
 	if _, err := os.Stat(privKeyPath); os.IsNotExist(err) {
 		return fmt.Errorf("A private key does not exist at path '%s'", privKeyPath)
 	}
-	err := issl.Verify(pubKeyPath, privKeyPath, hostname, selfSigned)
+	err := issl.Verify(pubKeyPath, privKeyPath, name, selfSigned)
 	var pubKeyBytes []byte
 	var privKeyBytes []byte
 	if err != nil && !ssl.IsHostnameMismatchErr(err) {
@@ -53,20 +53,40 @@ func CmdCreate(hostname, pubKeyPath, privKeyPath string, selfSigned, resolve boo
 			return err
 		}
 	}
-	err = ic.Create(hostname, string(pubKeyBytes), string(privKeyBytes), service.ID)
+	err = ic.Create(name, string(pubKeyBytes), string(privKeyBytes), service.ID)
 	if err != nil {
 		return err
 	}
-	logrus.Printf("Created '%s'", hostname)
+	logrus.Printf("Created '%s'", name)
 	logrus.Println("To make use of your cert, you need to add a site with the \"datica sites create\" command")
 	return nil
 }
 
-func (c *SCerts) Create(hostname, pubKey, privKey, svcID string) error {
+func (c *SCerts) Create(name, pubKey, privKey, svcID string) error {
 	cert := models.Cert{
-		Name:    hostname,
+		Name:    name,
 		PubKey:  pubKey,
 		PrivKey: privKey,
+	}
+	b, err := json.Marshal(cert)
+	if err != nil {
+		return err
+	}
+	headers := c.Settings.HTTPManager.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
+	resp, statusCode, err := c.Settings.HTTPManager.Post(b, fmt.Sprintf("%s%s/environments/%s/services/%s/certs", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID), headers)
+	if err != nil {
+		return err
+	}
+	return c.Settings.HTTPManager.ConvertResp(resp, statusCode, nil)
+}
+
+func (c *SCerts) CreateLetsEncrypt(name, svcID string) error {
+	var cert = struct {
+		Name        string `json:"name"`
+		LetsEncrypt bool   `json:"letsEncrypt"`
+	}{
+		Name:        name,
+		LetsEncrypt: true,
 	}
 	b, err := json.Marshal(cert)
 	if err != nil {

--- a/commands/certs/create.go
+++ b/commands/certs/create.go
@@ -14,48 +14,55 @@ import (
 	"github.com/daticahealth/cli/models"
 )
 
-func CmdCreate(name, pubKeyPath, privKeyPath string, selfSigned, resolve bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
+func CmdCreate(name, pubKeyPath, privKeyPath string, selfSigned, resolve, letsEncrypt bool, ic ICerts, is services.IServices, issl ssl.ISSL) error {
 	if strings.ContainsAny(name, config.InvalidChars) {
 		return fmt.Errorf("Invalid cert name. Names must not contain the following characters: %s", config.InvalidChars)
-	}
-	if _, err := os.Stat(pubKeyPath); os.IsNotExist(err) {
-		return fmt.Errorf("A cert does not exist at path '%s'", pubKeyPath)
-	}
-	if _, err := os.Stat(privKeyPath); os.IsNotExist(err) {
-		return fmt.Errorf("A private key does not exist at path '%s'", privKeyPath)
-	}
-	err := issl.Verify(pubKeyPath, privKeyPath, name, selfSigned)
-	var pubKeyBytes []byte
-	var privKeyBytes []byte
-	if err != nil && !ssl.IsHostnameMismatchErr(err) {
-		if ssl.IsIncompleteChainErr(err) && resolve {
-			pubKeyBytes, err = issl.Resolve(pubKeyPath)
-			if err != nil {
-				return fmt.Errorf("Could not resolve the incomplete certificate chain. If this is a self signed certificate, please re-run this command with the '-s' option: %s", err.Error())
-			}
-		} else {
-			return err
-		}
 	}
 	service, err := is.RetrieveByLabel("service_proxy")
 	if err != nil {
 		return err
 	}
-	if pubKeyBytes == nil {
-		pubKeyBytes, err = ioutil.ReadFile(pubKeyPath)
+	if letsEncrypt {
+		err = ic.CreateLetsEncrypt(name, service.ID)
 		if err != nil {
 			return err
 		}
-	}
-	if privKeyBytes == nil {
-		privKeyBytes, err = ioutil.ReadFile(privKeyPath)
+	} else {
+		if _, err := os.Stat(pubKeyPath); os.IsNotExist(err) {
+			return fmt.Errorf("A cert does not exist at path '%s'", pubKeyPath)
+		}
+		if _, err := os.Stat(privKeyPath); os.IsNotExist(err) {
+			return fmt.Errorf("A private key does not exist at path '%s'", privKeyPath)
+		}
+		err := issl.Verify(pubKeyPath, privKeyPath, name, selfSigned)
+		var pubKeyBytes []byte
+		var privKeyBytes []byte
+		if err != nil && !ssl.IsHostnameMismatchErr(err) {
+			if ssl.IsIncompleteChainErr(err) && resolve {
+				pubKeyBytes, err = issl.Resolve(pubKeyPath)
+				if err != nil {
+					return fmt.Errorf("Could not resolve the incomplete certificate chain. If this is a self signed certificate, please re-run this command with the '-s' option: %s", err.Error())
+				}
+			} else {
+				return err
+			}
+		}
+		if pubKeyBytes == nil {
+			pubKeyBytes, err = ioutil.ReadFile(pubKeyPath)
+			if err != nil {
+				return err
+			}
+		}
+		if privKeyBytes == nil {
+			privKeyBytes, err = ioutil.ReadFile(privKeyPath)
+			if err != nil {
+				return err
+			}
+		}
+		err = ic.Create(name, string(pubKeyBytes), string(privKeyBytes), service.ID)
 		if err != nil {
 			return err
 		}
-	}
-	err = ic.Create(name, string(pubKeyBytes), string(privKeyBytes), service.ID)
-	if err != nil {
-		return err
 	}
 	logrus.Printf("Created '%s'", name)
 	logrus.Println("To make use of your cert, you need to add a site with the \"datica sites create\" command")

--- a/commands/certs/create_test.go
+++ b/commands/certs/create_test.go
@@ -1,8 +1,10 @@
 package certs
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -77,7 +79,7 @@ func TestMain(m *testing.M) {
 }
 
 var certCreateTests = []struct {
-	hostname    string
+	name        string
 	pubKeyPath  string
 	privKeyPath string
 	selfSigned  bool
@@ -113,13 +115,48 @@ func TestCertsCreate(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdCreate(data.hostname, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
+		err := CmdCreate(data.name, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {
 			t.Errorf("Unexpected error: %s", err)
 			continue
 		}
+	}
+}
+
+func TestCertsCreateLetsEncrypt(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			defer r.Body.Close()
+			body, _ := ioutil.ReadAll(r.Body)
+			var certReq struct {
+				Name        string `json:"name"`
+				LetsEncrypt bool   `json:"letsEncrypt"`
+			}
+			err := json.Unmarshal(body, &certReq)
+			if err != nil || !certReq.LetsEncrypt || certReq.Name != certName {
+				w.WriteHeader(400)
+			}
+			fmt.Fprint(w, `{}`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+		},
+	)
+	// test
+	err := New(settings).CreateLetsEncrypt(certName, test.SvcID)
+
+	// assert
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
 	}
 }
 

--- a/commands/certs/list.go
+++ b/commands/certs/list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/models"
+	"github.com/olekukonko/tablewriter"
 )
 
 func CmdList(ic ICerts, is services.IServices) error {
@@ -21,10 +22,21 @@ func CmdList(ic ICerts, is services.IServices) error {
 		logrus.Println("No certs found")
 		return nil
 	}
-	logrus.Println("NAME")
+
+	data := [][]string{{"NAME", "LET'S ENCRYPT STATUS"}}
 	for _, cert := range *certs {
-		logrus.Println(cert.Name)
+		data = append(data, []string{cert.Name, cert.LetsEncrypt.String()})
 	}
+
+	table := tablewriter.NewWriter(logrus.StandardLogger().Out)
+	table.SetBorder(false)
+	table.SetRowLine(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetAutoWrapText(false)
+	table.AppendBulk(data)
+	table.Render()
 	return nil
 }
 

--- a/commands/certs/list_test.go
+++ b/commands/certs/list_test.go
@@ -16,7 +16,7 @@ func TestCertsList(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, `[{"name":"cert1"},{"name":"cert2"}]`)
+			fmt.Fprint(w, `[{"name":"cert0","letsEncrypt":0},{"name":"cert1","letsEncrypt":1},{"name":"cert2","letsEncrypt":2},{"name":"cert3","letsEncrypt":3}]`)
 		},
 	)
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",

--- a/commands/certs/rm.go
+++ b/commands/certs/rm.go
@@ -9,25 +9,25 @@ import (
 	"github.com/daticahealth/cli/config"
 )
 
-func CmdRm(hostname string, ic ICerts, is services.IServices) error {
-	if strings.ContainsAny(hostname, config.InvalidChars) {
-		return fmt.Errorf("Invalid cert hostname. Hostnames must not contain the following characters: %s", config.InvalidChars)
+func CmdRm(name string, ic ICerts, is services.IServices) error {
+	if strings.ContainsAny(name, config.InvalidChars) {
+		return fmt.Errorf("Invalid cert name. Names must not contain the following characters: %s", config.InvalidChars)
 	}
 	service, err := is.RetrieveByLabel("service_proxy")
 	if err != nil {
 		return err
 	}
-	err = ic.Rm(hostname, service.ID)
+	err = ic.Rm(name, service.ID)
 	if err != nil {
 		return err
 	}
-	logrus.Printf("Removed '%s'", hostname)
+	logrus.Printf("Removed '%s'", name)
 	return nil
 }
 
-func (c *SCerts) Rm(hostname, svcID string) error {
+func (c *SCerts) Rm(name, svcID string) error {
 	headers := c.Settings.HTTPManager.GetHeaders(c.Settings.SessionToken, c.Settings.Version, c.Settings.Pod, c.Settings.UsersID)
-	resp, statusCode, err := c.Settings.HTTPManager.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/certs/%s", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID, hostname), headers)
+	resp, statusCode, err := c.Settings.HTTPManager.Delete(nil, fmt.Sprintf("%s%s/environments/%s/services/%s/certs/%s", c.Settings.PaasHost, c.Settings.PaasHostVersion, c.Settings.EnvironmentID, svcID, name), headers)
 	if err != nil {
 		return err
 	}

--- a/commands/certs/rm_test.go
+++ b/commands/certs/rm_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var certRmTests = []struct {
-	hostname  string
+	name      string
 	expectErr bool
 }{
 	{certName, false},
@@ -38,7 +38,7 @@ func TestCertsRm(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRm(data.hostname, New(settings), services.New(settings))
+		err := CmdRm(data.name, New(settings), services.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/certs/update_test.go
+++ b/commands/certs/update_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var certUpdateTests = []struct {
-	hostname    string
+	name        string
 	pubKeyPath  string
 	privKeyPath string
 	selfSigned  bool
@@ -47,7 +47,7 @@ func TestCertsUpdate(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdUpdate(data.hostname, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
+		err := CmdUpdate(data.name, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/sites/contract.go
+++ b/commands/sites/contract.go
@@ -33,14 +33,14 @@ var CreateSubCmd = models.Command{
 	Name:      "create",
 	ShortHelp: "Create a new site linking it to an existing cert instance",
 	LongHelp: "`sites create` allows you to create a site configuration that is tied to a single service. " +
-		"To create a site, you must first [create a cert](#certs-create). " +
+		"To create a site, you must specify an existing cert made by the [certs create](#certs-create) command or use the \"-l\" flag to automatically create a Let's Encrypt certificate. " +
 		"A site has three pieces of information: a name, the service it's tied to, and the cert instance it will use. " +
 		"The name is the `server_name` that will be injected into this site's Nginx configuration file. " +
 		"It is important that this site name match what URL your site will respond to. " +
 		"If this is a bare domain, using `mysite.com` is sufficient. " +
 		"If it should respond to the APEX domain and all subdomains, it should be named `.mysite.com` notice the leading `.`. " +
 		"The service is a code service that will use this site configuration. " +
-		"Lastly, the cert instance must be specified by the `HOSTNAME` argument used in the [certs create](#certs-create) command. " +
+		"Lastly, the cert instance must be specified by the `CERT_NAME` argument used in the [certs create](#certs-create) command or by the \"-l\" flag indicating a new Let's Encrypt certificate should be created. " +
 		"You can also set Nginx configuration values directly by specifying one of the above flags. " +
 		"Specifying `--enable-cors` will add the following lines to your Nginx configuration\n\n" +
 		"```\nadd_header 'Access-Control-Allow-Origin' '$http_origin' always;\n" +

--- a/commands/sites/contract.go
+++ b/commands/sites/contract.go
@@ -57,7 +57,8 @@ var CreateSubCmd = models.Command{
 		"proxy_set_header Connection \"upgrade\";\n```\n\n" +
 		"Here are some sample commands\n\n" +
 		"```\ndatica -E \"<your_env_name>\" sites create .mysite.com app01 wildcard_mysitecom\n" +
-		"datica -E \"<your_env_name>\" sites create .mysite.com app01 wildcard_mysitecom --client-max-body-size 50 --enable-cors\n```",
+		"datica -E \"<your_env_name>\" sites create .mysite.com app01 wildcard_mysitecom --client-max-body-size 50 --enable-cors\n" +
+		"datica -E \"<your_env_name>\" sites create app01.mysite.com app01 --lets-encrypt --enable-websockets\n```",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
 			name := subCmd.StringArg("SITE_NAME", "", "The name of the site to be created. This will be used in this site's nginx configuration file (i.e. \".example.com\")")

--- a/commands/sites/contract.go
+++ b/commands/sites/contract.go
@@ -2,6 +2,7 @@ package sites
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/commands/certs"
 	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/config"
 	"github.com/daticahealth/cli/lib/auth"
@@ -61,7 +62,7 @@ var CreateSubCmd = models.Command{
 		return func(subCmd *cli.Cmd) {
 			name := subCmd.StringArg("SITE_NAME", "", "The name of the site to be created. This will be used in this site's nginx configuration file (i.e. \".example.com\")")
 			serviceName := subCmd.StringArg("SERVICE_NAME", "", "The name of the service to add this site configuration to (i.e. 'app01')")
-			hostname := subCmd.StringArg("HOSTNAME", "", "The hostname used in the creation of a certs instance with the 'certs' command (i.e. \"star_example_com\")")
+			certName := subCmd.StringArg("CERT_NAME", "", "The name of the cert created with the 'certs' command (i.e. \"star_example_com\")")
 			clientMaxBodySize := subCmd.IntOpt("client-max-body-size", -1, "The 'client_max_body_size' nginx config specified in megabytes")
 			proxyConnectTimeout := subCmd.IntOpt("proxy-connect-timeout", -1, "The 'proxy_connect_timeout' nginx config specified in seconds")
 			proxyReadTimeout := subCmd.IntOpt("proxy-read-timeout", -1, "The 'proxy_read_timeout' nginx config specified in seconds")
@@ -69,6 +70,7 @@ var CreateSubCmd = models.Command{
 			proxyUpstreamTimeout := subCmd.IntOpt("proxy-upstream-timeout", -1, "The 'proxy_next_upstream_timeout' nginx config specified in seconds")
 			enableCORS := subCmd.BoolOpt("enable-cors", false, "Enable or disable all features related to full CORS support")
 			enableWebSockets := subCmd.BoolOpt("enable-websockets", false, "Enable or disable all features related to full websockets support")
+			letsEncrypt := subCmd.BoolOpt("l lets-encrypt", false, "Whether or not this site should create an auto-renewing Let's Encrypt certificate")
 			subCmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -76,12 +78,12 @@ var CreateSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdCreate(*name, *serviceName, *hostname, *clientMaxBodySize, *proxyConnectTimeout, *proxyReadTimeout, *proxySendTimeout, *proxyUpstreamTimeout, *enableCORS, *enableWebSockets, New(settings), services.New(settings))
+				err := CmdCreate(*name, *serviceName, *certName, *clientMaxBodySize, *proxyConnectTimeout, *proxyReadTimeout, *proxySendTimeout, *proxyUpstreamTimeout, *enableCORS, *enableWebSockets, *letsEncrypt, New(settings), certs.New(settings), services.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
 			}
-			subCmd.Spec = "SITE_NAME SERVICE_NAME HOSTNAME [--client-max-body-size] [--proxy-connect-timeout] [--proxy-read-timeout] [--proxy-send-timeout] [--proxy-upstream-timeout] [--enable-cors] [--enable-websockets]"
+			subCmd.Spec = "SITE_NAME SERVICE_NAME (CERT_NAME | -l) [--client-max-body-size] [--proxy-connect-timeout] [--proxy-read-timeout] [--proxy-send-timeout] [--proxy-upstream-timeout] [--enable-cors] [--enable-websockets]"
 		}
 	},
 }

--- a/commands/sites/create.go
+++ b/commands/sites/create.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/commands/certs"
 	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/models"
 )
 
-func CmdCreate(name, serviceName, hostname string, clientMaxBodySize, proxyConnectTimeout, proxyReadTimeout, proxySendTimeout, proxyUpstreamTimeout int, enableCORS, enableWebSockets bool, is ISites, iservices services.IServices) error {
+func CmdCreate(name, serviceName, certName string, clientMaxBodySize, proxyConnectTimeout, proxyReadTimeout, proxySendTimeout, proxyUpstreamTimeout int, enableCORS, enableWebSockets, letsEncrypt bool, is ISites, ic certs.ICerts, iservices services.IServices) error {
 	upstreamService, err := iservices.RetrieveByLabel(serviceName)
 	if err != nil {
 		return err
@@ -23,7 +24,15 @@ func CmdCreate(name, serviceName, hostname string, clientMaxBodySize, proxyConne
 		return err
 	}
 
-	site, err := is.Create(name, hostname, upstreamService.ID, serviceProxy.ID, generateSiteValues(clientMaxBodySize, proxyConnectTimeout, proxyReadTimeout, proxySendTimeout, proxyUpstreamTimeout, enableCORS, enableWebSockets))
+	if letsEncrypt {
+		err = ic.CreateLetsEncrypt(name, serviceProxy.ID)
+		if err != nil {
+			return err
+		}
+		certName = name
+	}
+
+	site, err := is.Create(name, certName, upstreamService.ID, serviceProxy.ID, generateSiteValues(clientMaxBodySize, proxyConnectTimeout, proxyReadTimeout, proxySendTimeout, proxyUpstreamTimeout, enableCORS, enableWebSockets))
 	if err != nil {
 		return err
 	}

--- a/commands/sites/create_test.go
+++ b/commands/sites/create_test.go
@@ -1,0 +1,94 @@
+package sites
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/daticahealth/cli/commands/certs"
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/models"
+	"github.com/daticahealth/cli/test"
+)
+
+var createTests = []struct {
+	name                 string
+	svcName              string
+	certName             string
+	clientMaxBodySize    int
+	proxyConnectTimeout  int
+	proxyReadTimeout     int
+	proxySendTimeout     int
+	proxyUpstreamTimeout int
+	enableCORS           bool
+	enableWebSockets     bool
+	letsEncrypt          bool
+	expectErr            bool
+}{
+	{"test.example.com", "code-1", "test_example_com", -1, -1, -1, -1, -1, false, false, false, false},
+	{"test.example.com", "code-1", "test_example_com", -1, -1, -1, -1, -1, false, false, true, false},
+	{"test.example.com", "code-1", "test_example_com", 1, 2, 3, 4, 5, true, true, false, false},
+	{"test.example.com", "code-1", "test_example_com", 1, 2, 3, 4, 5, true, true, true, false},
+	{"test.example.com", "code-invalid", "test_example_com", 1, 2, 3, 4, 5, true, true, false, true},
+}
+
+func TestCreate(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	certNameSent := ""
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/certs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			defer r.Body.Close()
+			body, _ := ioutil.ReadAll(r.Body)
+			var certReq struct {
+				Name        string `json:"name"`
+				LetsEncrypt bool   `json:"letsEncrypt"`
+			}
+			err := json.Unmarshal(body, &certReq)
+			if err != nil || !certReq.LetsEncrypt {
+				w.WriteHeader(400)
+			}
+			fmt.Fprint(w, `{}`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/sites",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			defer r.Body.Close()
+			body, _ := ioutil.ReadAll(r.Body)
+			var site models.Site
+			json.Unmarshal(body, &site)
+			certNameSent = site.Name
+			fmt.Fprint(w, `{}`)
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"},{"id":"%s","label":"code-1"}]`, test.SvcID, test.SvcIDAlt))
+		},
+	)
+
+	for _, data := range createTests {
+		certNameSent = ""
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdCreate(data.name, data.svcName, data.certName, data.clientMaxBodySize, data.proxyConnectTimeout, data.proxyReadTimeout, data.proxySendTimeout, data.proxyUpstreamTimeout, data.enableCORS, data.enableWebSockets, data.letsEncrypt, New(settings), certs.New(settings), services.New(settings))
+
+		// assert
+		if err != nil != data.expectErr {
+			t.Errorf("Unexpected error: %s", err)
+			continue
+		}
+
+		if data.letsEncrypt && certNameSent != data.name {
+			t.Errorf("Let's Encrypt : %s", err)
+			continue
+		}
+	}
+}

--- a/models/models.go
+++ b/models/models.go
@@ -25,10 +25,11 @@ type Cert struct {
 	PubKey  string `json:"sslCertFile"`
 	PrivKey string `json:"sslPKFile"`
 
-	Service    string `json:"service,omitempty"`
-	PubKeyID   int    `json:"sslCertFileId,omitempty"`
-	PrivKeyID  int    `json:"sslPKFileId,omitempty"`
-	Restricted bool   `json:"restricted,omitempty"`
+	Service     string            `json:"service,omitempty"`
+	PubKeyID    int               `json:"sslCertFileId,omitempty"`
+	PrivKeyID   int               `json:"sslPKFileId,omitempty"`
+	Restricted  bool              `json:"restricted,omitempty"`
+	LetsEncrypt LetsEncryptStatus `json:"letsEncrypt,omitempty"`
 }
 
 type Command struct {
@@ -125,6 +126,30 @@ type Invite struct {
 	Email    string `json:"email"`
 	Consumed bool   `json:"consumed"`
 	Revoked  bool   `json:"revoked"`
+}
+
+// LetsEncryptStatus code
+type LetsEncryptStatus int
+
+const (
+	// NormalCert is a non-let's encrypt cert
+	NormalCert LetsEncryptStatus = iota
+	// Waiting verification and issuance
+	Waiting
+	// Valid certificate that has already been issued
+	Valid
+)
+
+func (l LetsEncryptStatus) String() string {
+	switch l {
+	case NormalCert:
+		return "This is not a Let's Encrypt certificate"
+	case Waiting:
+		return "Awaiting the certificate to be issued by Let's Encrypt"
+	case Valid:
+		return "Certificate successfully issued"
+	}
+	return ""
 }
 
 // LogHits contain ordering data for logs


### PR DESCRIPTION
The `sites create` command now allows automatically generating a Let's Encrypt certificate instead of specifying the name of an existing cert. This is done by specifying the `--lets-encrypt` flag instead of providing the `CERT_NAME` argument.

The `certs create` command also allows creating a Let's Encrypt certificate by providing the `--lets-encrypt` flag instead of the path to a public and private key.

Command examples are updated to reflect these options in the contract files.