### PR TITLE
Add service job logs

### DIFF
--- a/commands/logs/contract.go
+++ b/commands/logs/contract.go
@@ -15,6 +15,17 @@ import (
 	"github.com/jault3/mow.cli"
 )
 
+type CMDLogQuery struct {
+	Query   string // default *
+	Follow  bool
+	Hours   int
+	Minutes int
+	Seconds int
+	Service string
+	JobID   string
+	Target  string
+}
+
 // Cmd is the contract between the user and the CLI. This specifies the command
 // name, arguments, and required/optional arguments and flags for the command.
 var Cmd = models.Command{
@@ -22,11 +33,15 @@ var Cmd = models.Command{
 	ShortHelp: "Show the logs in your terminal streamed from your logging dashboard",
 	LongHelp: "`logs` prints out your application logs directly from your logging Dashboard. " +
 		"If you do not see your logs, try adjusting the number of hours, minutes, or seconds of logs that are retrieved with the `--hours`, `--minutes`, and `--seconds` options respectively. " +
+		"To specify a specific service, job, or target use the '--service', '--job-id', and '--target' commands. " +
+		"You must specify a service to use '--job-id' or '--target', and you cannot specify both a job-id and a target at the same time. " +
 		"You can also follow the logs with the `-f` option. " +
 		"When using `-f` all logs will be printed to the console within the given time frame as well as any new logs that are sent to the logging Dashboard for the duration of the command. " +
 		"When using the `-f` option, hit ctrl-c to stop. Here are some sample commands\n\n" +
 		"```\ndatica -E \"<your_env_name>\" logs --hours=6 --minutes=30\n" +
-		"datica -E \"<your_env_name>\" logs -f\n```",
+		"datica -E \"<your_env_name>\" logs -f\n" +
+		"datica -E \"<your_env_name>\" logs --service=\"<service_label>\" --job-id=\"<job-id>\"\n```",
+	// TODO: add documentation here
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(cmd *cli.Cmd) {
 			query := cmd.StringArg("QUERY", "*", "The query to send to your logging dashboard's elastic search (regex is supported)")
@@ -35,9 +50,9 @@ var Cmd = models.Command{
 			hours := cmd.IntOpt("hours", 0, "The number of hours before now (in combination with minutes and seconds) to retrieve logs")
 			mins := cmd.IntOpt("minutes", 0, "The number of minutes before now (in combination with hours and seconds) to retrieve logs")
 			secs := cmd.IntOpt("seconds", 0, "The number of seconds before now (in combination with hours and minutes) to retrieve logs")
-			service := cmd.StringOpt("service", "", "Query logs for only a service by service name")
-			jobID := cmd.StringOpt("job-id", "", "Query logs for only a particular job by job id")
-			target := cmd.StringOpt("target", "", "Query logs for only a particular service by procfile target")
+			service := cmd.StringOpt("service", "", "Query logs for a specific service label")
+			jobID := cmd.StringOpt("job-id", "", "Query logs for a particular job by id")
+			target := cmd.StringOpt("target", "", "Query logs for a particular procfile target")
 			cmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -45,7 +60,7 @@ var Cmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				cmdQuery := &logs.CMDLogQuery{
+				cmdQuery := CMDLogQuery{
 					Query:   *query,
 					Follow:  *follow || *tail,
 					Hours:   *hours,
@@ -55,7 +70,7 @@ var Cmd = models.Command{
 					JobID:   *jobID,
 					Target:  *target,
 				}
-				err := CmdLogs(cmdQuery, settings.EnvironmentID, settings, New(settings), prompts.New(), environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+				err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, New(settings), prompts.New(), environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -65,13 +80,13 @@ var Cmd = models.Command{
 	},
 }
 
-type queryGenerator func(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int) []byte
+type queryGenerator func(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int, hostNames []string, fileName string) ([]byte, error)
 
 // ILogs ...
 type ILogs interface {
-	Output(queryString, domain string, generator queryGenerator, from int, startTimestamp time.Time, endTimestamp time.Time) (int, error)
+	Output(queryString, domain string, generator queryGenerator, from int, startTimestamp time.Time, endTimestamp time.Time, hostNames []string, fileName string) (int, error)
 	RetrieveElasticsearchVersion(domain string) (string, error)
-	Stream(queryString, domain string, generator queryGenerator, from int, timestamp time.Time) error
+	Stream(queryString, domain string, generator queryGenerator, from int, timestamp time.Time, hostNames []string, fileName string) error
 	Watch(queryString, domain string) error
 }
 

--- a/commands/logs/contract.go
+++ b/commands/logs/contract.go
@@ -40,6 +40,7 @@ var Cmd = models.Command{
 		"When using the `-f` option, hit ctrl-c to stop. Here are some sample commands\n\n" +
 		"```\ndatica -E \"<your_env_name>\" logs --hours=6 --minutes=30\n" +
 		"datica -E \"<your_env_name>\" logs -f\n" +
+		"datica -E \"<your_env_name>\" logs --service=\"<your_service_name>\"\n" +
 		"datica -E \"<your_env_name>\" logs --service=\"<your_service_name>\" --job-id=\"<your_job_id>\"\n```",
 	// TODO: add documentation here
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
@@ -75,7 +76,7 @@ var Cmd = models.Command{
 					logrus.Fatal(err.Error())
 				}
 			}
-			cmd.Spec = "[QUERY] [(-f | -t)] [--hours] [--minutes] [--seconds] [--service] [--job-id] [--target]"
+			cmd.Spec = "[QUERY] [(-f | -t)] [--hours] [--minutes] [--seconds] [--service (--job-id | --target)]"
 		}
 	},
 }

--- a/commands/logs/contract.go
+++ b/commands/logs/contract.go
@@ -40,7 +40,7 @@ var Cmd = models.Command{
 		"When using the `-f` option, hit ctrl-c to stop. Here are some sample commands\n\n" +
 		"```\ndatica -E \"<your_env_name>\" logs --hours=6 --minutes=30\n" +
 		"datica -E \"<your_env_name>\" logs -f\n" +
-		"datica -E \"<your_env_name>\" logs --service=\"<service_label>\" --job-id=\"<job-id>\"\n```",
+		"datica -E \"<your_env_name>\" logs --service=\"<your_service_name>\" --job-id=\"<your_job_id>\"\n```",
 	// TODO: add documentation here
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(cmd *cli.Cmd) {

--- a/commands/logs/contract.go
+++ b/commands/logs/contract.go
@@ -76,7 +76,7 @@ var Cmd = models.Command{
 					logrus.Fatal(err.Error())
 				}
 			}
-			cmd.Spec = "[QUERY] [(-f | -t)] [--hours] [--minutes] [--seconds] [--service (--job-id | --target)]"
+			cmd.Spec = "[QUERY] [(-f | -t)] [--hours] [--minutes] [--seconds] [--service [(--job-id | --target)]]"
 		}
 	},
 }

--- a/commands/logs/es.go
+++ b/commands/logs/es.go
@@ -9,26 +9,30 @@ import (
 )
 
 func chooseQueryGenerator(version string) queryGenerator {
-	generator := generateES2Query
+	generator := generateES5Query
 	if strings.HasPrefix(version, "1.") {
 		generator = generateES1Query
+	} else if strings.HasPrefix(version, "2.") {
+		generator = generateES2Query
 	}
 	return generator
 }
 
-func generateES2Query(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int) []byte {
+func generateES5Query(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int, hostNames []string, fileName string) ([]byte, error) {
+	additionalFields, hostFilter, fileFilter := createFeildsAndFilters(hostNames, fileName, 2)
 	query := `{
-	"fields": ["@timestamp", "message", "` + appLogsIdentifier + `"],
+	"stored_fields": ["@timestamp", "message", "` + appLogsIdentifier + `"` + additionalFields + `],
 	"query": {
 		"wildcard": {
 			"message": "` + queryString + `"
 		}
 	},
-  "filter": {
+	"post_filter": {
 		"bool": {
 			"must": [
 				{"term": {"` + appLogsIdentifier + `": "` + appLogsValue + `"}},
 				{"range": {"@timestamp": {"gt": "` + fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ", timestamp.Year(), timestamp.Month(), timestamp.Day(), timestamp.Hour(), timestamp.Minute(), timestamp.Second()) + `"}}}
+				` + hostFilter + fileFilter + `
 			]
 		}
 	},
@@ -50,13 +54,17 @@ func generateES2Query(queryString, appLogsIdentifier, appLogsValue string, times
 	"size": ` + fmt.Sprintf("%d", size) + `
 	}`
 	var buf bytes.Buffer
-	json.Compact(&buf, []byte(query))
-	return buf.Bytes()
+	err := json.Compact(&buf, []byte(query))
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
-func generateES1Query(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int) []byte {
+func generateES2Query(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int, hostNames []string, fileName string) ([]byte, error) {
+	additionalFields, hostFilter, fileFilter := createFeildsAndFilters(hostNames, fileName, 2)
 	query := `{
-	"fields": ["@timestamp", "message", "` + appLogsIdentifier + `"],
+	"fields": ["@timestamp", "message", "` + appLogsIdentifier + `"` + additionalFields + `],
 	"query": {
 		"wildcard": {
 			"message": "` + queryString + `"
@@ -67,7 +75,51 @@ func generateES1Query(queryString, appLogsIdentifier, appLogsValue string, times
 			"must": [
 				{"term": {"` + appLogsIdentifier + `": "` + appLogsValue + `"}},
 				{"range": {"@timestamp": {"gt": "` + fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ", timestamp.Year(), timestamp.Month(), timestamp.Day(), timestamp.Hour(), timestamp.Minute(), timestamp.Second()) + `"}}}
+				` + hostFilter + fileFilter + `
 			]
+		}
+	},
+	"sort": [
+		{
+			"@timestamp": {
+				"order": "asc",
+				"unmapped_type":"boolean"
+			}
+		},
+		{
+			"message.raw": {
+				"order": "asc",
+				"unmapped_type":"boolean"
+			}
+		}
+	],
+	"from": ` + fmt.Sprintf("%d", from) + `,
+	"size": ` + fmt.Sprintf("%d", size) + `
+	}`
+	var buf bytes.Buffer
+	err := json.Compact(&buf, []byte(query))
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func generateES1Query(queryString, appLogsIdentifier, appLogsValue string, timestamp time.Time, from int, hostNames []string, fileName string) ([]byte, error) {
+	additionalFields, hostFilter, fileFilter := createFeildsAndFilters(hostNames, fileName, 1)
+	query := `{
+	"fields": ["@timestamp", "message", "` + appLogsIdentifier + `"` + additionalFields + `],
+	"query": {
+		"wildcard": {
+			"message": "` + queryString + `"
+		}
+	},
+	"filter": {
+		"bool": {
+			"must": [
+				{"term": {"` + appLogsIdentifier + `": "` + appLogsValue + `"}},
+				{"range": {"@timestamp": {"gt": "` + fmt.Sprintf("%04d-%02d-%02dT%02d:%02d:%02dZ", timestamp.Year(), timestamp.Month(), timestamp.Day(), timestamp.Hour(), timestamp.Minute(), timestamp.Second()) + `"}}}
+				` + fileFilter + `
+			]` + hostFilter + `
 		}
 	},
 	"sort": {
@@ -83,5 +135,35 @@ func generateES1Query(queryString, appLogsIdentifier, appLogsValue string, times
 	}`
 	var buf bytes.Buffer
 	json.Compact(&buf, []byte(query))
-	return buf.Bytes()
+	return buf.Bytes(), nil
+}
+
+func createFeildsAndFilters(hostNames []string, fileName string, version int) (string, string, string) {
+	var hostFilter string
+	var fileFilter string
+	var additionalFields string
+	if len(hostNames) > 0 {
+		if version >= 2 {
+			additionalFields += `, "host"`
+			for i, hostName := range hostNames {
+				hostNames[i] = fmt.Sprintf(`"%s"`, hostName)
+			}
+			hostFilter = fmt.Sprintf(`, {"terms": {"host": [%s]}}`, strings.Join(hostNames, ", "))
+		} else {
+			additionalFields += `, "host"`
+			hostFilter = `,
+			"should": [`
+			for _, hostName := range hostNames {
+				hostFilter += `
+				{"term": {"host": "` + hostName + `"}},`
+			}
+			hostFilter = strings.TrimSuffix(hostFilter, ",")
+			hostFilter += `
+			]`
+		}
+	} else if len(fileName) > 0 {
+		additionalFields += `, "file"`
+		fileFilter += `, {"term": {"file": "` + fileName + `"}}`
+	}
+	return additionalFields, hostFilter, fileFilter
 }

--- a/commands/logs/es.go
+++ b/commands/logs/es.go
@@ -15,7 +15,6 @@ func chooseQueryGenerator(version string) queryGenerator {
 	} else if strings.HasPrefix(version, "2.") {
 		generator = generateES2Query
 	}
-	fmt.Printf("Version: %s\n", version)
 	return generator
 }
 

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -25,18 +25,6 @@ type esVersion struct {
 	Number string `json:"number"`
 }
 
-// type CMDLogQuery struct {
-// 	Query    string // default *
-// 	Follow   bool
-// 	Hours    int
-// 	Minutes  int
-// 	Seconds  int
-// 	Service  string
-// 	JobID    string
-// 	Target   string
-// 	FileName string
-// }
-
 // CmdLogs is a way to stream logs from Kibana to your local terminal. This is
 // useful because Kibana is hard to look at because it splits every single
 // log statement into a separate block that spans multiple lines so it's

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -122,11 +122,10 @@ func CmdLogs(query *CMDLogQuery, envID string, settings *models.Settings, il ILo
 					targetString = fmt.Sprintf(` that have a target of "%s"`, query.Target)
 				}
 
-				if badCount < totalJobs {
-					//NOTE: This code path will most likely never be reached. Either all jobs should have valid hostnames, or none of them will
+				if badCount < totalJobs { //NOTE: This code path will most likely never be reached. Either all jobs should have valid hostnames, or none of them will
+					defer logrus.Println("To view logs for all jobs, please redeploy the service.")
 					prompt := fmt.Sprintf("Of the %d jobs for the service \"%s\"%s %d do not have a valid hostname to allow their logs to be queried. Would you like to proceed anyways?", totalJobs, query.Service, targetString, badCount)
 					err := ip.YesNo("(y/n)", prompt)
-					logrus.Println("To view logs for all jobs, please redeploy the service.")
 					if err != nil {
 						return err
 					}

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -141,11 +141,13 @@ func CmdLogs(query *CMDLogQuery, envID string, settings *models.Settings, il ILo
 				}
 
 				if badCount < totalJobs {
+					//NOTE: This code path will most likely never be reached. Either all jobs should have valid hostnames, or none of them will
 					prompt := fmt.Sprintf("Of the %d jobs for the service \"%s\"%s %d do not have a valid hostname to allow their logs to be queried. Would you like to proceed anyways?", totalJobs, query.Service, targetString, badCount)
 					err := ip.YesNo("(y/n)", prompt)
 					if err != nil {
 						return err
 					}
+					logrus.Println("To view logs for all jobs, please redeploy the service.")
 					hostNames = buildHostNames(jobs, svc.Label)
 				} else {
 					return fmt.Errorf(`All %d jobs for the service "%s"%s do not have valid hostnames to allow their logs to be queried. Redeploy the service if you would like to use this functionality.`, totalJobs, query.Service, targetString)

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -126,10 +126,10 @@ func CmdLogs(query *CMDLogQuery, envID string, settings *models.Settings, il ILo
 					//NOTE: This code path will most likely never be reached. Either all jobs should have valid hostnames, or none of them will
 					prompt := fmt.Sprintf("Of the %d jobs for the service \"%s\"%s %d do not have a valid hostname to allow their logs to be queried. Would you like to proceed anyways?", totalJobs, query.Service, targetString, badCount)
 					err := ip.YesNo("(y/n)", prompt)
+					logrus.Println("To view logs for all jobs, please redeploy the service.")
 					if err != nil {
 						return err
 					}
-					logrus.Println("To view logs for all jobs, please redeploy the service.")
 					hostNames = buildHostNames(jobs, svc.Label)
 				} else {
 					return fmt.Errorf(`All %d jobs for the service "%s"%s do not have valid hostnames to allow their logs to be queried. Redeploy the service if you would like to use this functionality.`, totalJobs, query.Service, targetString)

--- a/commands/logs/logs.go
+++ b/commands/logs/logs.go
@@ -45,15 +45,9 @@ func CmdLogs(query *CMDLogQuery, envID string, settings *models.Settings, il ILo
 		return fmt.Errorf("You must specify a code service to query the logs for a particular target")
 	}
 	var hostNames []string
-	//TODO: Get from service label if no jobID or target defined
-	//Replace all non alphanumeric characters with underscores
-	//Must check service type, not all filnames are defined the same
-	//If not code or  custom service, then fall back to hostName
-	//Get all deploy jobs for service, check if host names exist. If not, then can't do this command
 	var fileName string
 	isServiceQuery := false
 
-	// TODO: Fix tests for these cases (commented out to make go not freak out)
 	if len(query.Service) > 0 {
 		isServiceQuery = true
 		svc, err := is.RetrieveByLabel(query.Service)

--- a/commands/logs/logs_test.go
+++ b/commands/logs/logs_test.go
@@ -157,7 +157,6 @@ func muxSetup(mux *http.ServeMux, t *testing.T, serviceType string, createdAt []
 		// RetrieveByTarget/Type
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			// if query.Target == test.Target {
 			var jobs []string
 			for i, created := range createdAt {
 				jobID := test.JobID
@@ -168,10 +167,6 @@ func muxSetup(mux *http.ServeMux, t *testing.T, serviceType string, createdAt []
 			}
 			jobsJSON := fmt.Sprintf("[%s]", strings.Join(jobs, ","))
 			fmt.Fprint(w, jobsJSON)
-			// } else {
-			//
-			// 	fmt.Fprint(w, "")
-			// }
 		},
 	)
 	mux.HandleFunc("/environments",

--- a/commands/logs/logs_test.go
+++ b/commands/logs/logs_test.go
@@ -1,0 +1,536 @@
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/commands/environments"
+	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/commands/sites"
+	"github.com/daticahealth/cli/config"
+	"github.com/daticahealth/cli/lib/jobs"
+	"github.com/daticahealth/cli/models"
+	"github.com/daticahealth/cli/test"
+)
+
+type SLogsMock struct {
+	Settings *models.Settings
+}
+
+func (l *SLogsMock) RetrieveElasticsearchVersion(domain string) (string, error) {
+	// headers := map[string][]string{"Cookie": {"sessionToken=" + url.QueryEscape(l.Settings.SessionToken)}}
+	// resp, statusCode, err := l.Settings.HTTPManager.Get(nil, fmt.Sprintf("https://%s/__es/", domain), headers)
+	// if err != nil {
+	// 	return "", err
+	// }
+	// var wrapper struct {
+	// 	Version esVersion `json:"version"`
+	// }
+	// err = l.Settings.HTTPManager.ConvertResp(resp, statusCode, &wrapper)
+	// if err != nil {
+	// 	return "", err
+	// }
+	// return wrapper.Version.Number, nil
+	return "5", nil
+}
+
+func (l *SLogsMock) Output(queryString, domain string, generator queryGenerator, from int, startTimestamp, endTimestamp time.Time, hostNames []string, fileName string) (int, error) {
+	appLogsIdentifier := "source"
+	appLogsValue := "app"
+	if strings.HasPrefix(domain, "csb01") {
+		appLogsIdentifier = "syslog_program"
+		appLogsValue = "supervisord"
+	}
+
+	// urlString := fmt.Sprintf("https://%s/__es", domain)
+
+	// headers := map[string][]string{"Cookie": {"sessionToken=" + url.QueryEscape(l.Settings.SessionToken)}}
+
+	logrus.Println("        @timestamp       -        message")
+	for {
+		queryBytes, err := generator(queryString, appLogsIdentifier, appLogsValue, startTimestamp, from, hostNames, fileName)
+		if err != nil {
+			return -1, fmt.Errorf("Error generating query: %s", err)
+		} else if queryBytes == nil || len(queryBytes) == 0 {
+			return -1, errors.New("Error generating query")
+		}
+
+		// resp, statusCode, err := l.Settings.HTTPManager.Get(queryBytes, fmt.Sprintf("%s/_search", urlString), headers)
+		// if err != nil {
+		// 	return from, err
+		// }
+		var logs models.Logs
+		var hits models.Hits
+		logHits := []models.LogHits{}
+		for i := 0; i < 3; i++ {
+			var logHit models.LogHits
+			logHit.ID = fmt.Sprintf("log_%d", i)
+			logHit.Score = 2.3
+			logHit.Index = "1"
+			logHit.Type = "THeHittenistLogHit"
+			logHit.Fields = make(map[string][]string)
+			logHit.Fields["@timestamp"] = []string{fmt.Sprintf("2017-10-11T15:04:0%d.999999999Z07:00", i)}
+			logHit.Fields["message"] = []string{fmt.Sprintf("Wow so log %d", i)}
+			logHits = append(logHits, logHit)
+		}
+		hits.Hits = &logHits
+		hits.MaxScore = 2.3
+		hits.Total = 1
+		logs.Hits = &hits
+		// err = l.Settings.HTTPManager.ConvertResp(resp, statusCode, &logs)
+		// if err != nil {
+		// 	return from, err
+		// }
+
+		end := time.Time{}
+		for _, lh := range *logs.Hits.Hits {
+			logrus.Printf("%s - %s", lh.Fields["@timestamp"][0], lh.Fields["message"][0])
+			end, _ = time.Parse(time.RFC3339Nano, lh.Fields["@timestamp"][0])
+		}
+		amount := len(*logs.Hits.Hits)
+
+		from += len(*logs.Hits.Hits)
+		// TODO this will infinite loop if it always retrieves `size` hits
+		// and it fails to parse the end timestamp. very small window of opportunity.
+		if amount < size || end.After(endTimestamp) {
+			break
+		}
+		time.Sleep(config.JobPollTime * time.Second)
+	}
+	return from, nil
+}
+
+func (l *SLogsMock) Stream(queryString, domain string, generator queryGenerator, from int, timestamp time.Time, hostNames []string, fileName string) error {
+	//Don't want to run stream forever in test
+	for i := 0; i < 2; i++ {
+		f, err := l.Output(queryString, domain, generator, from, timestamp, time.Now(), hostNames, fileName)
+		if err != nil {
+			return err
+		}
+		from = f
+		time.Sleep(config.LogPollTime * time.Second)
+	}
+	return nil
+}
+
+func (l *SLogsMock) Watch(queryString, domain string) error {
+	//TODO: Mock it better?
+	return errors.New("Run Stream")
+}
+
+type SPromptsMock struct{}
+
+// EmailPassword prompts a user to enter their email and password.
+func (p *SPromptsMock) EmailPassword(existingEmail, existingPassword string) (string, string, error) {
+	return "email", "password", nil
+}
+
+func (p *SPromptsMock) KeyPassphrase(filepath string) string {
+	return "path/to/file"
+}
+
+func (p *SPromptsMock) PHI() error {
+	return nil
+}
+
+func (p *SPromptsMock) YesNo(msg, prompt string) error {
+	return nil
+}
+
+func (p *SPromptsMock) Password(msg string) string {
+	return "password"
+}
+
+func (p *SPromptsMock) OTP(preferredMode string) string {
+	return "token"
+}
+
+func (p *SPromptsMock) GenericPrompt(msg, prompt string, validOptions []string) string {
+	return "y"
+}
+
+func (p *SPromptsMock) CaptureInput(msg string) string {
+	return "y"
+}
+
+func muxSetup(mux *http.ServeMux, t *testing.T, serviceType string, hostNames []string, query *CMDLogQuery) {
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/",
+		// Retrieve services
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s","name":"%s","type":"%s","redeployable":false},{"id":"%s","label":"service_proxy","name":"service proxy","redeployable":true}]`, test.SvcID, test.SvcLabel, serviceType, serviceType, test.SvcIDAlt))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/jobs/"+query.JobID,
+		//Retrieve job
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			if query.JobID == test.JobID {
+				specJSON := fmt.Sprintf(`{
+						"payload": {
+							"environment": {"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}
+						},
+						"description": {
+							"hostName": "%s"
+						}
+					}`, test.EnvID, test.EnvName, test.Namespace, test.OrgID, hostNames[0])
+				jobJSON := fmt.Sprintf(`{"id":"%s","type":"%s","target":"%s","status":"happy","spec":%s}`, test.JobID, "deploy", test.Target, specJSON)
+				fmt.Fprint(w, jobJSON)
+			} else {
+				fmt.Fprint(w, "")
+			}
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcID+"/jobs",
+		// RetrieveByTarget
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			if query.Target == test.Target {
+				var jobs []string
+				for i, hostName := range hostNames {
+					specJSON := fmt.Sprintf(`{
+							"payload": {
+								"environment": {"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}
+							},
+							"description": {
+								"hostName": "%s"
+							}
+						}`, test.EnvID, test.EnvName, test.Namespace, test.OrgID, hostName)
+					jobID := test.JobID
+					if i > 0 {
+						jobID = test.JobIDAlt
+					}
+					jobs = append(jobs, fmt.Sprintf(`{"id":"%s","type":"%s","target":"%s","status":"happy","spec":%s}`, jobID, "worker", test.Target, specJSON))
+				}
+				jobsJSON := fmt.Sprintf("[%s]", strings.Join(jobs, ","))
+				fmt.Fprint(w, jobsJSON)
+			} else {
+				fmt.Fprint(w, "")
+			}
+		},
+	)
+	mux.HandleFunc("/environments",
+		// Retrieve environment list
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			if r.Header.Get("X-Pod-ID") == test.Pod {
+				fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}]`, test.EnvID, test.EnvName, test.Namespace, test.OrgID))
+			} else {
+				fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}]`, test.EnvIDAlt, test.EnvNameAlt, test.NamespaceAlt, test.OrgIDAlt))
+			}
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID,
+		// Retrieve environment by ID
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}`, test.EnvID, test.EnvName, test.Namespace, test.OrgID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+test.SvcIDAlt+"/sites",
+		// Retrieve site by ID
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":%d, "name":"%s"}]`, 123, test.Namespace+".supersite"))
+		},
+	)
+}
+
+func TestLogsService(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
+func TestLogsJobID(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		JobID:   test.JobID,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
+func TestLogsTarget(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		Target:  test.Target,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss", "oofOwieOuchHost"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
+func TestLogsStream(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  true,
+		Service: test.SvcLabel,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
+func TestLogsBadService(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: "BadServiceLabel",
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := fmt.Sprintf("Cannot find the specified service \"%s\".", cmdQuery.Service)
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadRequestMissingService(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:  "",
+		Follow: false,
+		Target: test.Target,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := "You must specify a code service to query the logs for a particular target"
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadRequestTargetAndJobID(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:  "",
+		Follow: false,
+		Target: test.Target,
+		JobID:  test.JobID,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := "Specifying \"--job-id\" in combination with \"--target\" is unsupported."
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadRequestTargetNonCodeService(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		Target:  test.Target,
+	}
+	muxSetup(mux, t, "database", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := "Cannot specifiy a target for a non-code service type"
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadServiceWithTarget(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: "BadServiceLabel",
+		Target:  test.Target,
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := fmt.Sprintf("Cannot find the specified service \"%s\".", cmdQuery.Service)
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadJobID(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		JobID:   "BadJobID",
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := fmt.Sprintf("Cannot find the specified job \"%s\".", cmdQuery.JobID)
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsBadTarget(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		Target:  "BadTarget",
+	}
+	muxSetup(mux, t, "code", []string{"hostinLikaBoss"}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := fmt.Sprintf("Cannot find any jobs with target \"%s\" for service \"%s\"", cmdQuery.Target, test.SvcID)
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsNoValidHostNames(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		Target:  test.Target,
+	}
+	muxSetup(mux, t, "code", []string{"", ""}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	expectedErr := fmt.Sprintf(`All %d jobs for the service "%s"%s do not have valid hostnames to allow their logs to be queried. Unable to proceed`, 2, cmdQuery.Service, fmt.Sprintf(` that have a target of "%s"`, cmdQuery.Target))
+	if err == nil {
+		t.Fatalf("Expected: %s\n", expectedErr)
+	} else if err.Error() != expectedErr {
+		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
+	}
+}
+
+func TestLogsOneValidHostName(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+	cmdQuery := CMDLogQuery{
+		Query:   "",
+		Follow:  false,
+		Service: test.SvcLabel,
+		Target:  test.Target,
+	}
+	muxSetup(mux, t, "code", []string{"", "developersdevelopersdevelopersdevelopers", "", ""}, &cmdQuery)
+
+	ilogs := &SLogsMock{
+		Settings: settings,
+	}
+
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}

--- a/commands/logs/logs_test.go
+++ b/commands/logs/logs_test.go
@@ -98,41 +98,6 @@ func (l *SLogsMock) Watch(queryString, domain string) error {
 	return errors.New("Run Stream")
 }
 
-type SPromptsMock struct{}
-
-// EmailPassword prompts a user to enter their email and password.
-func (p *SPromptsMock) EmailPassword(existingEmail, existingPassword string) (string, string, error) {
-	return "email", "password", nil
-}
-
-func (p *SPromptsMock) KeyPassphrase(filepath string) string {
-	return "path/to/file"
-}
-
-func (p *SPromptsMock) PHI() error {
-	return nil
-}
-
-func (p *SPromptsMock) YesNo(msg, prompt string) error {
-	return nil
-}
-
-func (p *SPromptsMock) Password(msg string) string {
-	return "password"
-}
-
-func (p *SPromptsMock) OTP(preferredMode string) string {
-	return "token"
-}
-
-func (p *SPromptsMock) GenericPrompt(msg, prompt string, validOptions []string) string {
-	return "y"
-}
-
-func (p *SPromptsMock) CaptureInput(msg string) string {
-	return "y"
-}
-
 func muxSetup(mux *http.ServeMux, t *testing.T, serviceType string, createdAt []string, query *CMDLogQuery) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services/",
 		// Retrieve services
@@ -210,7 +175,7 @@ func TestLogsService(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -231,7 +196,7 @@ func TestLogsJobID(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -252,7 +217,7 @@ func TestLogsTarget(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -272,7 +237,7 @@ func TestLogsStream(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -292,7 +257,7 @@ func TestLogsBadService(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := fmt.Sprintf("Cannot find the specified service \"%s\".", cmdQuery.Service)
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -315,7 +280,7 @@ func TestLogsBadRequestMissingService(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := "You must specify a code service to query the logs for a particular target"
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -339,7 +304,7 @@ func TestLogsBadRequestTargetAndJobID(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := "Specifying \"--job-id\" in combination with \"--target\" is unsupported."
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -363,7 +328,7 @@ func TestLogsBadRequestTargetNonCodeService(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := "Cannot specifiy a target for a non-code service type"
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -387,7 +352,7 @@ func TestLogsBadServiceWithTarget(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := fmt.Sprintf("Cannot find the specified service \"%s\".", cmdQuery.Service)
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -411,7 +376,7 @@ func TestLogsBadJobID(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := fmt.Sprintf("Cannot find the specified job \"%s\".", cmdQuery.JobID)
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -435,7 +400,7 @@ func TestLogsBadTarget(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := fmt.Sprintf("Cannot find any jobs with target \"%s\" for service \"%s\"", cmdQuery.Target, test.SvcID)
 	if err == nil {
 		t.Fatalf("Expected: %s\n", expectedErr)
@@ -459,7 +424,7 @@ func TestLogsNoValidHostNames(t *testing.T) {
 	ilogs := &SLogsMock{
 		Settings: settings,
 	}
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	expectedErr := fmt.Sprintf(`All %d jobs for the service "%s"%s do not have valid hostnames to allow their logs to be queried. Redeploy the service if you would like to use this functionality.`, 2, cmdQuery.Service, fmt.Sprintf(` that have a target of "%s"`, cmdQuery.Target))
 	if err == nil || err.Error() != expectedErr {
 		t.Fatalf("Expected: %s\nGot: %s", expectedErr, err)
@@ -482,7 +447,7 @@ func TestLogsOneValidHostName(t *testing.T) {
 		Settings: settings,
 	}
 
-	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &SPromptsMock{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
+	err := CmdLogs(&cmdQuery, settings.EnvironmentID, settings, ilogs, &test.FakePrompts{}, environments.New(settings), services.New(settings), jobs.New(settings), sites.New(settings))
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/commands/logs/logs_test.go
+++ b/commands/logs/logs_test.go
@@ -23,19 +23,6 @@ type SLogsMock struct {
 }
 
 func (l *SLogsMock) RetrieveElasticsearchVersion(domain string) (string, error) {
-	// headers := map[string][]string{"Cookie": {"sessionToken=" + url.QueryEscape(l.Settings.SessionToken)}}
-	// resp, statusCode, err := l.Settings.HTTPManager.Get(nil, fmt.Sprintf("https://%s/__es/", domain), headers)
-	// if err != nil {
-	// 	return "", err
-	// }
-	// var wrapper struct {
-	// 	Version esVersion `json:"version"`
-	// }
-	// err = l.Settings.HTTPManager.ConvertResp(resp, statusCode, &wrapper)
-	// if err != nil {
-	// 	return "", err
-	// }
-	// return wrapper.Version.Number, nil
 	return "5", nil
 }
 
@@ -47,10 +34,6 @@ func (l *SLogsMock) Output(queryString, domain string, generator queryGenerator,
 		appLogsValue = "supervisord"
 	}
 
-	// urlString := fmt.Sprintf("https://%s/__es", domain)
-
-	// headers := map[string][]string{"Cookie": {"sessionToken=" + url.QueryEscape(l.Settings.SessionToken)}}
-
 	logrus.Println("        @timestamp       -        message")
 	for {
 		queryBytes, err := generator(queryString, appLogsIdentifier, appLogsValue, startTimestamp, from, hostNames, fileName)
@@ -60,10 +43,6 @@ func (l *SLogsMock) Output(queryString, domain string, generator queryGenerator,
 			return -1, errors.New("Error generating query")
 		}
 
-		// resp, statusCode, err := l.Settings.HTTPManager.Get(queryBytes, fmt.Sprintf("%s/_search", urlString), headers)
-		// if err != nil {
-		// 	return from, err
-		// }
 		var logs models.Logs
 		var hits models.Hits
 		logHits := []models.LogHits{}
@@ -82,10 +61,6 @@ func (l *SLogsMock) Output(queryString, domain string, generator queryGenerator,
 		hits.MaxScore = 2.3
 		hits.Total = 1
 		logs.Hits = &hits
-		// err = l.Settings.HTTPManager.ConvertResp(resp, statusCode, &logs)
-		// if err != nil {
-		// 	return from, err
-		// }
 
 		end := time.Time{}
 		for _, lh := range *logs.Hits.Hits {

--- a/models/models.go
+++ b/models/models.go
@@ -235,6 +235,11 @@ type Payload struct {
 	Environment map[string]string `json:"environment"`
 }
 
+// Description is the description of a job
+type Description struct {
+	HostName string `json:"hostName"`
+}
+
 // Pod is a pod returned from the pod router
 type Pod struct {
 	Name string `json:"name"`
@@ -391,7 +396,8 @@ type Site struct {
 
 // Spec is a job specification
 type Spec struct {
-	Payload *Payload `json:"payload"`
+	Payload     *Payload     `json:"payload"`
+	Description *Description `json:"description"`
 }
 
 // TempURL holds a URL for uploading or downloading files from a temporary URL

--- a/models/models.go
+++ b/models/models.go
@@ -159,6 +159,7 @@ type LogHits struct {
 	ID     string              `json:"_id"`
 	Score  float64             `json:"_score"`
 	Fields map[string][]string `json:"fields"`
+	Source map[string]string   `json:"_source"`
 }
 
 // Login is used for making an authentication request
@@ -233,11 +234,6 @@ type OrgUser struct {
 // Payload is the payload of a job
 type Payload struct {
 	Environment map[string]string `json:"environment"`
-}
-
-// Description is the description of a job
-type Description struct {
-	HostName string `json:"hostName"`
 }
 
 // Pod is a pod returned from the pod router
@@ -396,8 +392,7 @@ type Site struct {
 
 // Spec is a job specification
 type Spec struct {
-	Payload     *Payload     `json:"payload"`
-	Description *Description `json:"description"`
+	Payload *Payload `json:"payload"`
 }
 
 // TempURL holds a URL for uploading or downloading files from a temporary URL

--- a/test/util.go
+++ b/test/util.go
@@ -19,6 +19,8 @@ const (
 	Pod       = "pod1"
 	SvcID     = "svc1"
 	SvcLabel  = "code1"
+	JobID     = "job1"
+	Target    = "target1"
 
 	AliasAlt     = "2"
 	EnvIDAlt     = "env2"
@@ -28,6 +30,8 @@ const (
 	PodAlt       = "pod2"
 	SvcIDAlt     = "svc2"
 	SvcLabelAlt  = "code2"
+	JobIDAlt     = "job2"
+	TargetAlt    = "target2"
 )
 
 func Setup() (*http.ServeMux, *httptest.Server, *url.URL) {

--- a/test/util.go
+++ b/test/util.go
@@ -19,7 +19,7 @@ const (
 	Pod       = "pod1"
 	SvcID     = "svc1"
 	SvcLabel  = "code1"
-	JobID     = "job1"
+	JobID     = "12345678"
 	Target    = "target1"
 
 	AliasAlt     = "2"
@@ -30,8 +30,11 @@ const (
 	PodAlt       = "pod2"
 	SvcIDAlt     = "svc2"
 	SvcLabelAlt  = "code2"
-	JobIDAlt     = "job2"
+	JobIDAlt     = "abcdefgh"
 	TargetAlt    = "target2"
+
+	GoodDate = "2017-09-24T17:23:04.999999999Z07:00"
+	BadDate  = "2017-09-22T17:23:04.999999999Z07:00"
 )
 
 func Setup() (*http.ServeMux, *httptest.Server, *url.URL) {


### PR DESCRIPTION
Added commands to view logs for a specific service, and jobs/targets within the service. Added in some additional fixes to query only logstash indices, not crash when timestamp or message is missing in a log, and to work with ES5.