### PR TITLE
Edit successful content verification text so it's not confusing when …

### DIFF
--- a/commands/images/pull.go
+++ b/commands/images/pull.go
@@ -36,7 +36,7 @@ func cmdImagePull(envID, name string, user *models.User, ie environments.IEnviro
 	if subtle.ConstantTimeCompare(target.Hashes[image.Digest.HashType], hashBytes) == 0 {
 		return fmt.Errorf("Content verification failed. Image content does not match the signed target.")
 	}
-	logrus.Printf("\nSuccessfully verified image %s against signed target in remote trust repository\n", fullImageName)
+	logrus.Printf("\nSuccessfully verified image %s against signed target in trust repository.\n", fullImageName)
 
 	return nil
 }

--- a/lib/images/tuf.go
+++ b/lib/images/tuf.go
@@ -199,7 +199,7 @@ func (d *SImages) ListTargets(repo notaryClient.Repository, roles ...string) ([]
 	return targets, nil
 }
 
-// LookupTarget searches for a specific target in a repository by tag name
+// Target searches for a specific target in a repository by tag name
 func (d *SImages) LookupTarget(repo notaryClient.Repository, tag string) (*notaryClient.TargetWithRole, error) {
 	target, err := repo.GetTargetByName(tag)
 	if err != nil {

--- a/lib/images/tuf.go
+++ b/lib/images/tuf.go
@@ -199,7 +199,7 @@ func (d *SImages) ListTargets(repo notaryClient.Repository, roles ...string) ([]
 	return targets, nil
 }
 
-// Target searches for a specific target in a repository by tag name
+// LookupTarget searches for a specific target in a repository by tag name
 func (d *SImages) LookupTarget(repo notaryClient.Repository, tag string) (*notaryClient.TargetWithRole, error) {
 	target, err := repo.GetTargetByName(tag)
 	if err != nil {


### PR DESCRIPTION
…remote trust repo is unreachable but the content is still verified against local trust data