### PR TITLE
Set default docker API version to 1.35

### DIFF
--- a/lib/images/tuf.go
+++ b/lib/images/tuf.go
@@ -105,6 +105,9 @@ func (d *SImages) Push(name string, user *models.User, env *models.Environment, 
 
 	out, err := dockerCli.ImagePush(ctx, fullImageName, types.ImagePushOptions{RegistryAuth: dockerAuth(user)})
 	if err != nil {
+		if matched, _ := regexp.MatchString(InvalidDockerAPIVersion, err.Error()); matched {
+			return nil, fmt.Errorf("%s\nSet environment variable `DOCKER_API_VERSION` to match your local installation", err.Error())
+		}
 		return nil, err
 	}
 	defer out.Close()

--- a/vendor/github.com/docker/docker/api/common.go
+++ b/vendor/github.com/docker/docker/api/common.go
@@ -3,7 +3,7 @@ package api
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.36"
+	DefaultVersion string = "1.35"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.


### PR DESCRIPTION
For some reason all the sudden the docker daemon started complaining about the version of the rest API (possibly because I just reset my daemon? who knows). Anywho, this makes it be quiet.