### PR TITLE
Image namespace parsing stdev 1639

### DIFF
--- a/commands/certs/create_test.go
+++ b/commands/certs/create_test.go
@@ -82,16 +82,17 @@ var certCreateTests = []struct {
 	name        string
 	pubKeyPath  string
 	privKeyPath string
+	downStream  string
 	selfSigned  bool
 	resolve     bool
 	expectErr   bool
 }{
-	{certName, pubKeyPath, privKeyPath, true, true, false},
-	{certName, pubKeyPath, privKeyPath, true, false, false},
-	{certName, pubKeyPath, privKeyPath, false, true, false},
-	{certName, pubKeyPath, invalidPath, true, true, true},
-	{certName, invalidPath, privKeyPath, true, true, true},
-	{"/?%", pubKeyPath, privKeyPath, true, true, true},
+	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, true, false},
+	// {certName, pubKeyPath, privKeyPath, test.SvcLabel, true, false, false},
+	// {certName, pubKeyPath, privKeyPath, test.SvcLabel, false, true, false},
+	// {certName, pubKeyPath, invalidPath, test.SvcLabel, true, true, true},
+	// {certName, invalidPath, privKeyPath, test.SvcLabel, true, true, true},
+	// {"/?%", pubKeyPath, privKeyPath, test.SvcLabel, true, true, true},
 }
 
 func TestCertsCreate(t *testing.T) {
@@ -107,7 +108,7 @@ func TestCertsCreate(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
 		},
 	)
 
@@ -115,7 +116,7 @@ func TestCertsCreate(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdCreate(data.name, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, false, New(settings), services.New(settings), ssl.New(settings))
+		err := CmdCreate(data.name, data.pubKeyPath, data.privKeyPath, data.downStream, data.selfSigned, data.resolve, false, New(settings), services.New(settings), ssl.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {
@@ -172,7 +173,7 @@ func TestCertsCreateFailSSL(t *testing.T) {
 	)
 
 	// test
-	err := CmdCreate(certName, pubKeyPath, privKeyPath, false, false, false, New(settings), services.New(settings), ssl.New(settings))
+	err := CmdCreate(certName, pubKeyPath, privKeyPath, test.SvcLabel, false, false, false, New(settings), services.New(settings), ssl.New(settings))
 
 	// assert
 	if err == nil {

--- a/commands/certs/create_test.go
+++ b/commands/certs/create_test.go
@@ -87,12 +87,12 @@ var certCreateTests = []struct {
 	resolve     bool
 	expectErr   bool
 }{
-	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, true, false},
-	// {certName, pubKeyPath, privKeyPath, test.SvcLabel, true, false, false},
-	// {certName, pubKeyPath, privKeyPath, test.SvcLabel, false, true, false},
-	// {certName, pubKeyPath, invalidPath, test.SvcLabel, true, true, true},
-	// {certName, invalidPath, privKeyPath, test.SvcLabel, true, true, true},
-	// {"/?%", pubKeyPath, privKeyPath, test.SvcLabel, true, true, true},
+	{certName, pubKeyPath, privKeyPath, test.DownStream, true, true, false},
+	{certName, pubKeyPath, privKeyPath, test.DownStream, true, false, false},
+	{certName, pubKeyPath, privKeyPath, test.DownStream, false, true, false},
+	{certName, pubKeyPath, invalidPath, test.DownStream, true, true, true},
+	{certName, invalidPath, privKeyPath, test.DownStream, true, true, true},
+	{"/?%", pubKeyPath, privKeyPath, test.DownStream, true, true, true},
 }
 
 func TestCertsCreate(t *testing.T) {
@@ -108,7 +108,7 @@ func TestCertsCreate(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 
@@ -149,7 +149,7 @@ func TestCertsCreateLetsEncrypt(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 	// test
@@ -168,12 +168,12 @@ func TestCertsCreateFailSSL(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 
 	// test
-	err := CmdCreate(certName, pubKeyPath, privKeyPath, test.SvcLabel, false, false, false, New(settings), services.New(settings), ssl.New(settings))
+	err := CmdCreate(certName, pubKeyPath, privKeyPath, test.DownStream, false, false, false, New(settings), services.New(settings), ssl.New(settings))
 
 	// assert
 	if err == nil {

--- a/commands/certs/list_test.go
+++ b/commands/certs/list_test.go
@@ -22,12 +22,12 @@ func TestCertsList(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
 		},
 	)
 
 	// test
-	err := CmdList(New(settings), services.New(settings))
+	err := CmdList(New(settings), services.New(settings), test.SvcLabel)
 
 	// assert
 	if err != nil {

--- a/commands/certs/list_test.go
+++ b/commands/certs/list_test.go
@@ -22,12 +22,12 @@ func TestCertsList(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 
 	// test
-	err := CmdList(New(settings), services.New(settings), test.SvcLabel)
+	err := CmdList(New(settings), services.New(settings), test.DownStream)
 
 	// assert
 	if err != nil {

--- a/commands/certs/rm_test.go
+++ b/commands/certs/rm_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 var certRmTests = []struct {
-	name      string
-	expectErr bool
+	name       string
+	downStream string
+	expectErr  bool
 }{
-	{certName, false},
-	{"bad-cert-name", true},
+	{certName, test.SvcLabel, false},
+	{"bad-cert-name", test.SvcLabel, true},
 }
 
 func TestCertsRm(t *testing.T) {
@@ -30,7 +31,7 @@ func TestCertsRm(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
 		},
 	)
 
@@ -38,7 +39,7 @@ func TestCertsRm(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRm(data.name, New(settings), services.New(settings))
+		err := CmdRm(data.name, New(settings), services.New(settings), data.downStream)
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/certs/rm_test.go
+++ b/commands/certs/rm_test.go
@@ -14,8 +14,8 @@ var certRmTests = []struct {
 	downStream string
 	expectErr  bool
 }{
-	{certName, test.SvcLabel, false},
-	{"bad-cert-name", test.SvcLabel, true},
+	{certName, test.DownStream, false},
+	{"bad-cert-name", test.DownStream, true},
 }
 
 func TestCertsRm(t *testing.T) {
@@ -31,7 +31,7 @@ func TestCertsRm(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 

--- a/commands/certs/update_test.go
+++ b/commands/certs/update_test.go
@@ -19,12 +19,12 @@ var certUpdateTests = []struct {
 	resolve     bool
 	expectErr   bool
 }{
-	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, false, false},
-	{certName, invalidPath, privKeyPath, test.SvcLabel, true, false, true}, // invalid cert path
-	{certName, pubKeyPath, invalidPath, test.SvcLabel, true, false, true},  // invalid key path
-	{certName, pubKeyPath, privKeyPath, test.SvcLabel, false, false, true}, // cert not signed by CA
-	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, true, false},
-	{"bad-cert-name", pubKeyPath, privKeyPath, test.SvcLabel, true, false, true},
+	{certName, pubKeyPath, privKeyPath, test.DownStream, true, false, false},
+	{certName, invalidPath, privKeyPath, test.DownStream, true, false, true}, // invalid cert path
+	{certName, pubKeyPath, invalidPath, test.DownStream, true, false, true},  // invalid key path
+	{certName, pubKeyPath, privKeyPath, test.DownStream, false, false, true}, // cert not signed by CA
+	{certName, pubKeyPath, privKeyPath, test.DownStream, true, true, false},
+	{"bad-cert-name", pubKeyPath, privKeyPath, test.DownStream, true, false, true},
 }
 
 func TestCertsUpdate(t *testing.T) {
@@ -40,7 +40,7 @@ func TestCertsUpdate(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.DownStream))
 		},
 	)
 

--- a/commands/certs/update_test.go
+++ b/commands/certs/update_test.go
@@ -14,16 +14,17 @@ var certUpdateTests = []struct {
 	name        string
 	pubKeyPath  string
 	privKeyPath string
+	downStream  string
 	selfSigned  bool
 	resolve     bool
 	expectErr   bool
 }{
-	{certName, pubKeyPath, privKeyPath, true, false, false},
-	{certName, invalidPath, privKeyPath, true, false, true}, // invalid cert path
-	{certName, pubKeyPath, invalidPath, true, false, true},  // invalid key path
-	{certName, pubKeyPath, privKeyPath, false, false, true}, // cert not signed by CA
-	{certName, pubKeyPath, privKeyPath, true, true, false},
-	{"bad-cert-name", pubKeyPath, privKeyPath, true, false, true},
+	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, false, false},
+	{certName, invalidPath, privKeyPath, test.SvcLabel, true, false, true}, // invalid cert path
+	{certName, pubKeyPath, invalidPath, test.SvcLabel, true, false, true},  // invalid key path
+	{certName, pubKeyPath, privKeyPath, test.SvcLabel, false, false, true}, // cert not signed by CA
+	{certName, pubKeyPath, privKeyPath, test.SvcLabel, true, true, false},
+	{"bad-cert-name", pubKeyPath, privKeyPath, test.SvcLabel, true, false, true},
 }
 
 func TestCertsUpdate(t *testing.T) {
@@ -39,7 +40,7 @@ func TestCertsUpdate(t *testing.T) {
 	mux.HandleFunc("/environments/"+test.EnvID+"/services",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"service_proxy"}]`, test.SvcID))
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, test.SvcID, test.SvcLabel))
 		},
 	)
 
@@ -47,7 +48,7 @@ func TestCertsUpdate(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdUpdate(data.name, data.pubKeyPath, data.privKeyPath, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
+		err := CmdUpdate(data.name, data.pubKeyPath, data.privKeyPath, data.downStream, data.selfSigned, data.resolve, New(settings), services.New(settings), ssl.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/deploy/contract.go
+++ b/commands/deploy/contract.go
@@ -6,6 +6,7 @@ import (
 	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/config"
 	"github.com/daticahealth/cli/lib/auth"
+	"github.com/daticahealth/cli/lib/images"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/lib/prompts"
 	"github.com/daticahealth/cli/models"
@@ -20,7 +21,7 @@ var Cmd = models.Command{
 	LongHelp: "<code>deploy</code> deploys a Docker image for the given service. " +
 		"This command will only deploy for \"container\" services. " +
 		"Here is a sample command\n\n" +
-		"<pre>\ndatica -E \"<your_env_name>\" deploy container01 image01\n</pre>",
+		"<pre>\ndatica -E \"<your_env_name>\" deploy <service> <image>:<tag>\n</pre>",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(cmd *cli.Cmd) {
 			serviceName := cmd.StringArg("SERVICE_NAME", "", "The name of the service to deploy to (e.g. 'container01')")
@@ -32,7 +33,7 @@ var Cmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdDeploy(settings.EnvironmentID, *serviceName, *imageName, jobs.New(settings), services.New(settings), environments.New(settings))
+				err := CmdDeploy(settings.EnvironmentID, *serviceName, *imageName, jobs.New(settings), services.New(settings), environments.New(settings), images.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}

--- a/commands/deploy/deploy.go
+++ b/commands/deploy/deploy.go
@@ -6,10 +6,11 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/daticahealth/cli/commands/environments"
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/images"
 	"github.com/daticahealth/cli/lib/jobs"
 )
 
-func CmdDeploy(envID, svcName, imgName string, ij jobs.IJobs, is services.IServices, ie environments.IEnvironments) error {
+func CmdDeploy(envID, svcName, imgName string, ij jobs.IJobs, is services.IServices, ie environments.IEnvironments, ii images.IImages) error {
 	env, err := ie.Retrieve(envID)
 	if err != nil {
 		return err
@@ -21,8 +22,17 @@ func CmdDeploy(envID, svcName, imgName string, ij jobs.IJobs, is services.IServi
 	if service == nil {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"datica services list\" command.", svcName)
 	}
-	logrus.Printf("Deploying image %s to service %s (ID = %s) in environment %s (ID = %s)", imgName, svcName, service.ID, env.Name, env.ID)
-	err = ij.DeployRelease(imgName, service.ID)
+
+	namespacedImage, tag, err := ii.GetGloballyUniqueNamespace(imgName, env, false)
+	if err != nil {
+		return err
+	} else if tag == "" {
+		return fmt.Errorf("Must specify which tag to deploy for the image")
+	}
+	imageTag := fmt.Sprintf("%s:%s", namespacedImage, tag)
+
+	logrus.Printf("Deploying image %s to service %s (ID = %s) in environment %s (ID = %s)", imageTag, svcName, service.ID, env.Name, env.ID)
+	err = ij.DeployRelease(imageTag, service.ID)
 	if err != nil {
 		return err
 	}

--- a/commands/deploy/deploy_test.go
+++ b/commands/deploy/deploy_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/daticahealth/cli/commands/environments"
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/images"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
 )
 
 const (
 	container = "container01"
-	image     = "/namespace/image:tag"
+	image1    = "/" + test.Namespace + "/" + test.Image + ":" + test.Tag
+	image2    = test.Image + ":" + test.Tag
 )
 
 var deployTests = []struct {
@@ -22,9 +24,15 @@ var deployTests = []struct {
 	image     string
 	expectErr bool
 }{
-	{container, image, false},
-	{"badcontainerservice", image, true},
+	// SUCCEED
+	{container, image1, false},
+	{container, image2, false},
+	{container, test.Registry + image1, false},
+	// FAIL
+	{"badcontainerservice", image1, true},
 	{container, "/invalid/tag:name", true},
+	{container, test.Registry + "/invalid/tag:name", true},
+	{container, "notag", true},
 }
 
 func TestDeploy(t *testing.T) {
@@ -58,10 +66,10 @@ func TestDeploy(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdDeploy(settings.EnvironmentID, data.container, data.image, jobs.New(settings), services.New(settings), environments.New(settings))
+		err := CmdDeploy(settings.EnvironmentID, data.container, data.image, jobs.New(settings), services.New(settings), environments.New(settings), images.New(settings))
 
 		// assert
-		if err != nil != data.expectErr {
+		if (err != nil) != data.expectErr {
 			t.Errorf("Unexpected error: %s", err)
 			continue
 		}

--- a/commands/images/tags/contract.go
+++ b/commands/images/tags/contract.go
@@ -2,6 +2,7 @@ package tags
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/commands/environments"
 	"github.com/daticahealth/cli/config"
 	"github.com/daticahealth/cli/lib/auth"
 	"github.com/daticahealth/cli/lib/images"
@@ -40,7 +41,7 @@ var listCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := cmdTagList(images.New(settings), *image)
+				err := cmdTagList(images.New(settings), environments.New(settings), settings.EnvironmentID, *image)
 				if err != nil {
 					logrus.Fatalln(err.Error())
 				}
@@ -53,11 +54,10 @@ var deleteCmd = models.Command{
 	Name:      "rm",
 	ShortHelp: "Delete a tag for a given image",
 	LongHelp: "Delete a tag for a given image. Example:\n" +
-		"<pre>\ndatica -E \"<your_env_name>\" images tags delete pod012345/my-image v1\n</pre>",
+		"<pre>\ndatica -E \"<your_env_name>\" images tags delete <namespace>/<image>:<tag>\n</pre>",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(cmd *cli.Cmd) {
-			image := cmd.StringArg("IMAGE_NAME", "", "The name of the image to list tags for, including the environment's namespace.")
-			tag := cmd.StringArg("TAG", "", "The tag to delete.")
+			image := cmd.StringArg("IMAGE_NAME", "", "The tagged name of the image to delete.")
 			cmd.Action = func() {
 				if _, err := auth.New(settings, prompts.New()).Signin(); err != nil {
 					logrus.Fatal(err.Error())
@@ -65,7 +65,7 @@ var deleteCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := cmdTagDelete(images.New(settings), prompts.New(), *image, *tag)
+				err := cmdTagDelete(images.New(settings), prompts.New(), environments.New(settings), settings.EnvironmentID, *image)
 				if err != nil {
 					logrus.Fatalln(err.Error())
 				}

--- a/commands/images/tags/list.go
+++ b/commands/images/tags/list.go
@@ -4,11 +4,20 @@ import (
 	"sort"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/daticahealth/cli/commands/environments"
 	"github.com/daticahealth/cli/lib/images"
 )
 
-func cmdTagList(ii images.IImages, image string) error {
-	tags, err := ii.ListTags(image)
+func cmdTagList(ii images.IImages, ie environments.IEnvironments, envID, image string) error {
+	env, err := ie.Retrieve(envID)
+	if err != nil {
+		return err
+	}
+	namespacedImage, _, err := ii.GetGloballyUniqueNamespace(image, env, false)
+	if err != nil {
+		return err
+	}
+	tags, err := ii.ListTags(namespacedImage)
 	if err != nil {
 		return err
 	}

--- a/commands/images/tags/list_test.go
+++ b/commands/images/tags/list_test.go
@@ -5,25 +5,43 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/daticahealth/cli/commands/environments"
 	"github.com/daticahealth/cli/lib/images"
 	"github.com/daticahealth/cli/test"
 )
+
+var listTagsTests = []struct {
+	imageName string
+	expectErr bool
+}{
+	{"hello", false},
+	{"hello:tag", false},
+	{fmt.Sprintf("%s/hello", test.Namespace), false},
+	{fmt.Sprintf("%s/%s/hello", test.Registry, test.Namespace), false},
+	{fmt.Sprintf("%s/invalid/hello", test.Registry), true},
+}
 
 func TestListTags(t *testing.T) {
 	mux, server, baseURL := test.Setup()
 	defer test.Teardown(server)
 	settings := test.GetSettings(baseURL.String())
-
-	mux.HandleFunc(fmt.Sprintf("/environments/"+test.EnvID+"/images/test1234%%2Fhello/tags"),
+	mux.HandleFunc("/environments/"+test.EnvID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","name":"%s","namespace":"%s","organizationId":"%s"}`, test.EnvID, test.EnvName, test.Namespace, test.OrgID))
+		},
+	)
+	mux.HandleFunc(fmt.Sprintf("/environments/"+test.EnvID+"/images/"+test.Namespace+"%%2F"+"hello/tags"),
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
 			fmt.Fprint(w, `["v1", "v2", "latest"]`)
 		},
 	)
 
-	err := cmdTagList(images.New(settings), "test1234/hello")
-
-	if err != nil {
-		t.Fatalf("Unexpected error while listing tags: %v", err)
+	for _, data := range listTagsTests {
+		err := cmdTagList(images.New(settings), environments.New(settings), settings.EnvironmentID, data.imageName)
+		if (err != nil) != data.expectErr {
+			t.Fatalf("Unexpected error while listing tags: %v", err)
+		}
 	}
 }

--- a/commands/images/targets/delete.go
+++ b/commands/images/targets/delete.go
@@ -16,7 +16,7 @@ func cmdTargetsDelete(envID, imageName string, user *models.User, ie environment
 		return err
 	}
 	var targetList []string
-	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env)
+	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env, true)
 	if err != nil {
 		return err
 	}

--- a/commands/images/targets/list.go
+++ b/commands/images/targets/list.go
@@ -20,7 +20,7 @@ func cmdTargetsList(envID, imageName string, user *models.User, ie environments.
 
 	var targets []*notaryClient.TargetWithRole
 
-	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env)
+	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env, true)
 	if err != nil {
 		return err
 	}

--- a/commands/images/targets/reset.go
+++ b/commands/images/targets/reset.go
@@ -17,7 +17,7 @@ func cmdTargetsReset(envID, imageName string, user *models.User, ie environments
 		return err
 	}
 
-	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env)
+	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env, true)
 	if err != nil {
 		return err
 	}

--- a/commands/images/targets/status.go
+++ b/commands/images/targets/status.go
@@ -14,7 +14,7 @@ func cmdTargetsStatus(envID, imageName string, user *models.User, ie environment
 		return err
 	}
 
-	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env)
+	repositoryName, tag, err := ii.GetGloballyUniqueNamespace(imageName, env, true)
 	if err != nil {
 		return err
 	}

--- a/lib/images/contract.go
+++ b/lib/images/contract.go
@@ -22,7 +22,7 @@ type IImages interface {
 	PrintChangelist(changes []changelist.Change)
 	CheckChangelist(repo notaryClient.Repository, ip prompts.IPrompts) error
 	GetNotaryRepository(pod, imageName string, user *models.User) notaryClient.Repository
-	GetGloballyUniqueNamespace(name string, env *models.Environment) (string, string, error)
+	GetGloballyUniqueNamespace(name string, env *models.Environment, includeRegistry bool) (string, string, error)
 	Publish(repo notaryClient.Repository) error
 }
 

--- a/lib/images/tuf.go
+++ b/lib/images/tuf.go
@@ -313,10 +313,9 @@ func (d *SImages) GetGloballyUniqueNamespace(name string, env *models.Environmen
 	repoParts := strings.Split(image, "/")
 	registry := getServer(env.Pod, registries)
 
-	var namespace, repo string
+	var repo string
 	switch len(repoParts) {
 	case 1:
-		namespace = env.Namespace
 		repo = repoParts[0]
 	case 2:
 		if repoParts[0] != env.Namespace {
@@ -326,21 +325,19 @@ func (d *SImages) GetGloballyUniqueNamespace(name string, env *models.Environmen
 			//Allow users to pull public images
 			return image, tag, nil
 		}
-		namespace = repoParts[0]
 		repo = repoParts[1]
 	case 3:
 		if repoParts[0] != registry || repoParts[1] != env.Namespace {
 			return "", "", fmt.Errorf(IncorrectRegistryOrNamespace)
 		}
-		namespace = repoParts[1]
 		repo = repoParts[2]
 	default:
 		return "", "", fmt.Errorf(InvalidImageName)
 	}
 	if includeRegistry {
-		repositoryName = fmt.Sprintf("%s/%s/%s", registry, namespace, repo)
+		repositoryName = fmt.Sprintf("%s/%s/%s", registry, env.Namespace, repo)
 	} else {
-		repositoryName = fmt.Sprintf("%s/%s", namespace, repo)
+		repositoryName = fmt.Sprintf("%s/%s", env.Namespace, repo)
 	}
 	return repositoryName, tag, nil
 }

--- a/test/tuf-mock.go
+++ b/test/tuf-mock.go
@@ -24,8 +24,9 @@ type FakeImages struct {
 
 // Testing constants
 const (
-	Image = "hello-world"
-	Tag   = "latest"
+	Registry = "registry.datica.com"
+	Image    = "hello-world"
+	Tag      = "latest"
 )
 
 var testDigest = &models.ContentDigest{

--- a/test/util.go
+++ b/test/util.go
@@ -33,8 +33,9 @@ const (
 	JobIDAlt     = "abcdefgh"
 	TargetAlt    = "target2"
 
-	GoodDate = "2017-09-24T17:23:04.999999999Z07:00"
-	BadDate  = "2017-09-22T17:23:04.999999999Z07:00"
+	DownStream = "service_proxy"
+	GoodDate   = "2017-09-24T17:23:04.999999999Z07:00"
+	BadDate    = "2017-09-22T17:23:04.999999999Z07:00"
 )
 
 func Setup() (*http.ServeMux, *httptest.Server, *url.URL) {


### PR DESCRIPTION
**Commands edited for namespace parsing**

1. datica images tags list
2. datica images tags rm
3. datica deploy

Wrote tests for images tags list, images tags rm, and deploy to confirm they all work with any of the following formats:
- ```<registry>/<namespace>/<image>:<tag>```
- ```<namespace>/<image>:<tag>```
- ```<image>:<tag>```

Updated `images tags rm` to follow the pattern of other related commands, where tag is included in image name

This PR also includes test fixes for STDEV-1627 so that I could run all test on Jenkins

