### PR TITLE
Fix output for container service releases

### DIFF
--- a/commands/releases/list.go
+++ b/commands/releases/list.go
@@ -3,6 +3,7 @@ package releases
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -50,8 +51,13 @@ func CmdList(svcName string, ir IReleases, is services.IServices) error {
 	data := [][]string{{"Release Name", "Created At", "Notes"}}
 	for _, r := range *rls {
 		name := r.Name
-		if r.Name == service.ReleaseVersion {
-			name = fmt.Sprintf("*%s", r.Name)
+		if service.Type == "container" {
+			repoParts := strings.SplitN(r.Repository, "/", 2)
+			image := repoParts[len(repoParts)-1]
+			name = fmt.Sprintf("%s:%s", image, name)
+		}
+		if r.Name == service.ReleaseVersion && r.Repository == service.Image {
+			name = fmt.Sprintf("*%s", name)
 		}
 		t, _ := time.Parse(dateForm, r.CreatedAt)
 		data = append(data, []string{name, t.Local().Format(time.ANSIC), r.Notes})

--- a/models/models.go
+++ b/models/models.go
@@ -291,9 +291,10 @@ type PostInvite struct {
 }
 
 type Release struct {
-	Name      string `json:"release,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	Notes     string `json:"metadata,omitempty"`
+	Name       string `json:"release,omitempty"`
+	Repository string `json:"repository,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+	Notes      string `json:"metadata,omitempty"`
 }
 
 // ReportedError is the standard error model sent back from the API
@@ -322,6 +323,7 @@ type Service struct {
 	LBIP           string            `json:"load_balancer_ip,omitempty"`
 	Scale          int               `json:"scale,omitempty"`
 	WorkerScale    int               `json:"worker_scale,omitempty"`
+	Image          string            `json:"docker_image,omitempty"`
 	ReleaseVersion string            `json:"release_version,omitempty"`
 	Redeployable   bool              `json:"redeployable,omitempty"`
 }


### PR DESCRIPTION
Output container service release name as image:tag and check both image repo and release to mark as deployed, instead of marking all releases with the same tag as currently released.