### PR TITLE
Autocomplete

### DIFF
--- a/datica_autocomplete
+++ b/datica_autocomplete
@@ -8,8 +8,8 @@ _datica_autocomplete() {
   local cur prev opts
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[COMP_CWORD-1]}"
-  opts="$(_commands "${COMP_WORDS[*]}")"
+  prev="${COMP_WORDS[*]:0:$COMP_CWORD}"
+  opts="$(_commands "$prev")"
   COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0
 }

--- a/datica_autocomplete
+++ b/datica_autocomplete
@@ -1,14 +1,14 @@
 #! /bin/bash
 
 _commands() {
-  eval "$@ --help" 2>&1 | awk '/^Commands:/ {start=1; next} start==1 && !/^$/ {print $1} $1 ~ /^$/ {start=0}'
+  datica $@ --help 2>&1 | awk '/^Commands:/ {start=1; next} start==1 && !/^$/ {print $1} $1 ~ /^$/ {start=0}'
 }
 
 _datica_autocomplete() {
   local cur prev opts
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[*]:0:$COMP_CWORD}"
+  prev="${COMP_WORDS[*]:1:$COMP_CWORD-1}"
   opts="$(_commands "$prev")"
   COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0

--- a/datica_autocomplete
+++ b/datica_autocomplete
@@ -1,17 +1,17 @@
 #! /bin/bash
 
 _commands() {
-  datica --help 2>&1 | awk '/^Commands:/ {start=1; next} start==1 && !/^$/ {print $1} $1 ~ /^$/ {start=0}'
+  eval "$@ --help" 2>&1 | awk '/^Commands:/ {start=1; next} start==1 && !/^$/ {print $1} $1 ~ /^$/ {start=0}'
 }
 
 _datica_autocomplete() {
-     local cur prev opts base
-     COMPREPLY=()
-     cur="${COMP_WORDS[COMP_CWORD]}"
-     prev="${COMP_WORDS[COMP_CWORD-1]}"
-     opts="$(_commands)"
-     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-     return 0
- }
+  local cur prev opts
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  opts="$(_commands "${COMP_WORDS[*]}")"
+  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  return 0
+}
 
- complete -F _datica_autocomplete datica
+complete -F _datica_autocomplete datica


### PR DESCRIPTION
Passing previously seen command args to the autocomplete script which allows the `--help` flag to run on the commands you've already typed allowing you to get the help from the subcommands. I also removed extra whitespace from the front of the lines.

I've tested this with `bash`, `sh`, and `zsh` without issues. This is a low-risk commit and changes nothing with the CLI code.

Examples:
Level One Autocomplete:
```
bash-4.4$ datica
certs         db            domain        git-remote    invites       logout        metrics       releases      sites         support-ids   vars          worker
clear         deploy        environments  images        jobs          logs          rake          rollback      ssl           update        version
console       deploy-keys   files         init          keys          maintenance   redeploy      services      status        users         whoami
```

Level Two Autocomplete:
```
bash-4.4$ datica db
backup    download  export    import    list      logs
```