### PR TITLE
Fix mongo parameter issue, enhance init command, log cleanup

### DIFF
--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -190,7 +190,7 @@ func (d *SDb) Import(rt *transfer.ReaderTransfer, key, iv []byte, mongoCollectio
 			if uploadResp == nil {
 				logrus.Printf("\nChunk upload %s failed.\nErr: %s\nRetrying...", strconv.Itoa(i), fmt.Errorf("No response from server"))
 			} else {
-				logrus.Printf("\nChunk upload %s failed.\nResponse code: %s\nErr: %s\nRetrying...", strconv.Itoa(i), uploadResp.StatusCode, err)
+				logrus.Printf("\nChunk upload %s failed.\nResponse code: %s\nErr: %s\nRetrying...", strconv.Itoa(i), strconv.Itoa(uploadResp.StatusCode), err)
 			}
 			time.Sleep(time.Second * 15)
 		}

--- a/commands/init/contract.go
+++ b/commands/init/contract.go
@@ -14,19 +14,24 @@ var Cmd = models.Command{
 	Name:      "init",
 	ShortHelp: "Get started using the Datica platform",
 	LongHelp: "The <code>init</code> command walks you through setting up the CLI to use with the Datica platform. " +
-		"The <code>init</code> command requires you to have an environment already set up. ",
+		"The <code>init</code> command requires access to an environment with a code service. ",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(cmd *cli.Cmd) {
+			service := cmd.StringArg("SERVICE", "", "Service name to use. If not provided, and the environment has more than one, you will be asked for a choice.")
+			remoteName := cmd.StringOpt("remote-name", "datica", "Name to use for the git remote.")
+			noInput := cmd.BoolOpt("no-input", false, "If set, this command does not prompt for input. Environment and service must be explicitly provided.")
+			overwriteRemote := cmd.BoolOpt("overwrite-remote", false, "If set, and the git remote named by --remote-name already exists for this repository, overwrite it without prompting.")
 			cmd.Action = func() {
 				p := prompts.New()
 				if _, err := auth.New(settings, p).Signin(); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdInit(settings, p)
+				err := CmdInit(*service, *noInput, *remoteName, *overwriteRemote, settings, p)
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
 			}
+			cmd.Spec = "[SERVICE] [--remote-name] [--overwrite-remote] [--no-input]"
 		}
 	},
 }

--- a/commands/init/init.go
+++ b/commands/init/init.go
@@ -28,7 +28,7 @@ func CmdInit(serviceName string, noInput bool, remoteName string, overwriteRemot
 		if noInput {
 			return errors.New("--no-input was passed - both environment and service need to be explicitly provided.")
 		}
-		logrus.Println("To set up your local repository, we need to know what environment and service you want to push your code to.")
+		logrus.Println("To set up your local repository, you must specify what environment and service you want to push your code to.")
 	}
 
 	ip := pods.New(settings)

--- a/config/constants.go
+++ b/config/constants.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// VERSION is the current cli version
-	VERSION = "4.3.1"
+	VERSION = "4.3.2"
 	// Beta determines whether or not this is a beta build of the CLI
 	Beta = false
 	// AccountsHost is the production accounts URL

--- a/config/settings.go
+++ b/config/settings.go
@@ -175,6 +175,7 @@ func SaveSettings(settings *models.Settings) error {
 // in the given settings object. It then populates the EnvironmentID and
 // ServiceID on the settings object with appropriate values.
 func SetGivenEnv(envMatch string, settings *models.Settings) {
+	settings.GivenEnvName = envMatch
 	for _, e := range settings.Environments {
 		if e.Name == envMatch || e.EnvironmentID == envMatch {
 			settings.EnvironmentID = e.EnvironmentID


### PR DESCRIPTION
This PR lumps a number of changes together.

1. Re-added mongo parameters to `db import` that were lost in the multipart changes.
2. Sync up release versioning commits so that the 4.3.1 hotfix is actually in the repo history.
3. Fix issue #86 - the underlying cause is still unknown, but error messages should at least be getting fed through properly, now.
4. Added optional `-E` support to `init` (was previously getting ignored)
5. Cleaned up some repetitive/misleading language in `init`
6. Added optional support to `init` to specify the service name and avoid having to find it in the list.
7. Added option `--remote-name` to `init` to allow a remote name other than `datica` to be used.
8. Added option `--overwrite-remote` to `init` to automatically overwrite the specified remote if it already exists (useful for automation).
9. Added option `--no-input` to `init` to error out instead of ask for input if any information is missing (useful for automation).
10. Preemptively bumped version to `4.3.2`