### PR TITLE
Add support for compressed db backups

### DIFF
--- a/commands/db/backup_test.go
+++ b/commands/db/backup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -70,7 +71,7 @@ func TestDbBackup(t *testing.T) {
 		queriedJob = false
 
 		// test
-		err := CmdBackup(data.databaseName, data.skipPoll, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+		err := CmdBackup(data.databaseName, data.skipPoll, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/db/contract.go
+++ b/commands/db/contract.go
@@ -10,6 +10,7 @@ import (
 	"github.com/daticahealth/cli/commands/services"
 	"github.com/daticahealth/cli/config"
 	"github.com/daticahealth/cli/lib/auth"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/lib/prompts"
@@ -56,7 +57,7 @@ var BackupSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdBackup(*databaseName, *skipPoll, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+				err := CmdBackup(*databaseName, *skipPoll, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -89,7 +90,7 @@ var DownloadSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdDownload(*databaseName, *backupID, *filePath, *force, New(settings, crypto.New(), jobs.New(settings)), prompts.New(), services.New(settings))
+				err := CmdDownload(*databaseName, *backupID, *filePath, *force, New(settings, crypto.New(), compress.New(), jobs.New(settings)), prompts.New(), services.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -121,7 +122,7 @@ var ExportSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdExport(*databaseName, *filePath, *force, New(settings, crypto.New(), jobs.New(settings)), prompts.New(), services.New(settings), jobs.New(settings))
+				err := CmdExport(*databaseName, *filePath, *force, New(settings, crypto.New(), compress.New(), jobs.New(settings)), prompts.New(), services.New(settings), jobs.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -159,7 +160,7 @@ var ImportSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdImport(*databaseName, *filePath, *mongoCollection, *mongoDatabase, *skipBackup, New(settings, crypto.New(), jobs.New(settings)), prompts.New(), services.New(settings), jobs.New(settings))
+				err := CmdImport(*databaseName, *filePath, *mongoCollection, *mongoDatabase, *skipBackup, New(settings, crypto.New(), compress.New(), jobs.New(settings)), prompts.New(), services.New(settings), jobs.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -187,7 +188,7 @@ var ListSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdList(*databaseName, *page, *pageSize, New(settings, crypto.New(), jobs.New(settings)), services.New(settings))
+				err := CmdList(*databaseName, *page, *pageSize, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -214,7 +215,7 @@ var LogsSubCmd = models.Command{
 				if err := config.CheckRequiredAssociation(settings); err != nil {
 					logrus.Fatal(err.Error())
 				}
-				err := CmdLogs(*databaseName, *backupID, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+				err := CmdLogs(*databaseName, *backupID, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
 				if err != nil {
 					logrus.Fatal(err.Error())
 				}
@@ -241,14 +242,16 @@ type IDb interface {
 type SDb struct {
 	Settings *models.Settings
 	Crypto   crypto.ICrypto
+	Compress compress.ICompress
 	Jobs     jobs.IJobs
 }
 
 // New returns an instance of IDb
-func New(settings *models.Settings, crypto crypto.ICrypto, jobs jobs.IJobs) IDb {
+func New(settings *models.Settings, crypto crypto.ICrypto, compress compress.ICompress, jobs jobs.IJobs) IDb {
 	return &SDb{
 		Settings: settings,
 		Crypto:   crypto,
+		Compress: compress,
 		Jobs:     jobs,
 	}
 }

--- a/commands/db/download_test.go
+++ b/commands/db/download_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -64,7 +65,7 @@ func TestDbDownload(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdDownload(data.databaseName, data.backupID, data.filePath, data.force, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+		err := CmdDownload(data.databaseName, data.backupID, data.filePath, data.force, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
 
 		// assert
 		if err != nil {

--- a/commands/db/export.go
+++ b/commands/db/export.go
@@ -110,7 +110,7 @@ func (d *SDb) Export(filePath string, job *models.Job, service *models.Service) 
 	}
 	contentEncoding := resp.Header.Get("Content-Encoding")
 	if contentEncoding == "gzip" {
-		file, err = d.Compress.NewDecompressWriteCloser(file, contentEncoding)
+		file, err = d.Compress.NewDecompressWriteCloser(file)
 		if err != nil {
 			return err
 		}

--- a/commands/db/export.go
+++ b/commands/db/export.go
@@ -83,11 +83,7 @@ func (d *SDb) Export(filePath string, job *models.Job, service *models.Service) 
 	if err != nil {
 		return err
 	}
-	tr := &http.Transport{ // gzip encoded backups must first be decrypted
-		DisableCompression: true, // Disable automatic decompress
-	}
-	client := &http.Client{Transport: tr}
-	resp, err := client.Get(tempURL.URL)
+	resp, err := http.Get(tempURL.URL)
 	if err != nil {
 		return err
 	}
@@ -108,8 +104,8 @@ func (d *SDb) Export(filePath string, job *models.Job, service *models.Service) 
 	if err != nil {
 		return err
 	}
-	contentEncoding := resp.Header.Get("Content-Encoding")
-	if contentEncoding == "gzip" {
+	backupCompression := resp.Header.Get("x-amz-meta-datica-backup-compression")
+	if backupCompression == "gzip" {
 		file, err = d.Compress.NewDecompressWriteCloser(file)
 		if err != nil {
 			return err

--- a/commands/db/export_test.go
+++ b/commands/db/export_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -27,8 +28,78 @@ var dbExportTests = []struct {
 	{dbName, exportFilePath, true, false}, // same filename with force passes
 	{"invalid-svc", exportFilePath, true, true},
 }
-
 func TestDbExport(t *testing.T) {
+	mux, server, baseURL := test.Setup()
+	defer test.Teardown(server)
+	settings := test.GetSettings(baseURL.String())
+
+	mux.HandleFunc("/environments/"+test.EnvID+"/services",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`[{"id":"%s","label":"%s"}]`, dbID, dbName))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "POST")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"running","backup":{"key":"0000000000000000000000000000000000000000000000000000000000000000","keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/jobs/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","isSnapshotBackup":false,"type":"backup","status":"finished","backup":{"key":"0000000000000000000000000000000000000000000000000000000000000000","keyLogs":"0000000000000000000000000000000000000000000000000000000000000000","iv":"000000000000000000000000"}}`, dbJobID))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/backup"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/environments/"+test.EnvID+"/services/"+dbID+"/backup-restore-logs-url/"+dbJobID,
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			fmt.Fprint(w, fmt.Sprintf(`{"url":"%s/backup"}`, baseURL.String()))
+		},
+	)
+	mux.HandleFunc("/logs",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Write([]byte{186, 194, 51, 73, 71, 71, 38, 3, 182, 216, 210, 144, 156, 237, 120, 227, 95, 91, 197, 59, 19}) // gcm encrypted "test"
+		},
+	)
+	mux.HandleFunc("/backup",
+		func(w http.ResponseWriter, r *http.Request) {
+			test.AssertEquals(t, r.Method, "GET")
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Write([]byte{209, 44, 72, 61, 170, 141, 222, 50, 7, 77, 238, 154, 191, 243, 71, 35, 32, 87, 1, 202, 55, 166, 53, 255, 217, 162, 8, 99, 192, 90, 53, 141, 246, 100, 176, 40, 162, 199, 66, 105, 67, 232, 89, 36, 88, 135, 62, 247, 72, 175, 126, 189, 129, 184, 156, 50, 97, 239, 27, 52, 153, 13, 58, 31, 208, 0, 133, 34, 178, 168, 138, 94, 1, 4, 248, 121, 204, 184, 152, 136, 176}) // gcm encrypted gzip compressed "test" (concatenation of three gzip streams ["te", "st", "\n"], extra length is due to multiple compression headers)
+		},
+	)
+
+	for _, data := range dbExportTests {
+		t.Logf("Data: %+v", data)
+
+		// test
+		err := CmdExport(data.databaseName, data.filePath, data.force, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+
+		// assert
+		if err != nil {
+			if !data.expectErr {
+				t.Errorf("Unexpected error: %s", err)
+			}
+			continue
+		}
+
+		b, _ := ioutil.ReadFile(data.filePath)
+		if strings.TrimSpace(string(b)) != "test" {
+			t.Errorf("Unexpected file contents. Expected: test, actual: %s", string(b))
+		}
+	}
+	os.Remove(exportFilePath)
+}
+
+func TestDbExportUncompressed(t *testing.T) {
 	mux, server, baseURL := test.Setup()
 	defer test.Teardown(server)
 	settings := test.GetSettings(baseURL.String())
@@ -80,7 +151,7 @@ func TestDbExport(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdExport(data.databaseName, data.filePath, data.force, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+		err := CmdExport(data.databaseName, data.filePath, data.force, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
 
 		// assert
 		if err != nil {

--- a/commands/db/export_test.go
+++ b/commands/db/export_test.go
@@ -72,7 +72,7 @@ func TestDbExport(t *testing.T) {
 	mux.HandleFunc("/backup",
 		func(w http.ResponseWriter, r *http.Request) {
 			test.AssertEquals(t, r.Method, "GET")
-			w.Header().Set("Content-Encoding", "gzip")
+			w.Header().Set("x-amz-meta-datica-backup-compression", "gzip")
 			w.Write([]byte{209, 44, 72, 61, 170, 141, 222, 50, 7, 77, 238, 154, 191, 243, 71, 35, 32, 87, 1, 202, 55, 166, 53, 255, 217, 162, 8, 99, 192, 90, 53, 141, 246, 100, 176, 40, 162, 199, 66, 105, 67, 232, 89, 36, 88, 135, 62, 247, 72, 175, 126, 189, 129, 184, 156, 50, 97, 239, 27, 52, 153, 13, 58, 31, 208, 0, 133, 34, 178, 168, 138, 94, 1, 4, 248, 121, 204, 184, 152, 136, 176}) // gcm encrypted gzip compressed "test" (concatenation of three gzip streams ["te", "st", "\n"], extra length is due to multiple compression headers)
 		},
 	)

--- a/commands/db/import_test.go
+++ b/commands/db/import_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -120,7 +121,7 @@ func TestDbImport(t *testing.T) {
 		backedUp = false
 
 		// test
-		err := CmdImport(data.databaseName, data.filePath, data.collection, data.database, data.skipBackup, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+		err := CmdImport(data.databaseName, data.filePath, data.collection, data.database, data.skipBackup, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
 
 		// assert
 		if err != nil {
@@ -227,7 +228,7 @@ func TestDbImportOverFiveGB(t *testing.T) {
 		backedUp = false
 
 		// test
-		err := CmdImport(data.databaseName, data.filePath, data.collection, data.database, data.skipBackup, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+		err := CmdImport(data.databaseName, data.filePath, data.collection, data.database, data.skipBackup, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
 
 		// assert
 		if err != nil {
@@ -291,7 +292,7 @@ func TestDbImportFailedUpload(t *testing.T) {
 	)
 
 	// test
-	err := CmdImport(dbName, importFilePath, "", "", true, New(settings, crypto.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
+	err := CmdImport(dbName, importFilePath, "", "", true, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings), jobs.New(settings))
 
 	// assert
 	if err == nil {

--- a/commands/db/list_test.go
+++ b/commands/db/list_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -44,7 +45,7 @@ func TestDbList(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdList(data.databaseName, data.page, data.pageSize, New(settings, crypto.New(), jobs.New(settings)), services.New(settings))
+		err := CmdList(data.databaseName, data.page, data.pageSize, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings))
 
 		// assert
 		if err != nil != data.expectErr {

--- a/commands/db/logs_test.go
+++ b/commands/db/logs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/daticahealth/cli/commands/services"
+	"github.com/daticahealth/cli/lib/compress"
 	"github.com/daticahealth/cli/lib/crypto"
 	"github.com/daticahealth/cli/lib/jobs"
 	"github.com/daticahealth/cli/test"
@@ -62,7 +63,7 @@ func TestDbLogs(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdLogs(data.databaseName, data.jobID, New(settings, crypto.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
+		err := CmdLogs(data.databaseName, data.jobID, New(settings, crypto.New(), compress.New(), jobs.New(settings)), services.New(settings), jobs.New(settings))
 
 		// assert
 		if err != nil {

--- a/lib/compress/contract.go
+++ b/lib/compress/contract.go
@@ -1,0 +1,18 @@
+package compress
+
+import (
+	"io"
+)
+
+// ICompress
+type ICompress interface {
+	NewDecompressWriteCloser(writeCloser io.WriteCloser, compressionType string) (*DecompressWriteCloser, error)
+}
+
+// SCompress is an implementor of ICompress
+type SCompress struct{}
+
+// New creates a new instance of SCompress
+func New() ICompress {
+	return &SCompress{}
+}

--- a/lib/compress/contract.go
+++ b/lib/compress/contract.go
@@ -6,7 +6,7 @@ import (
 
 // ICompress
 type ICompress interface {
-	NewDecompressWriteCloser(writeCloser io.WriteCloser, compressionType string) (*DecompressWriteCloser, error)
+	NewDecompressWriteCloser(writeCloser io.WriteCloser) (*DecompressWriteCloser, error)
 }
 
 // SCompress is an implementor of ICompress

--- a/lib/compress/decompress.go
+++ b/lib/compress/decompress.go
@@ -1,0 +1,55 @@
+package compress
+
+import (
+	"compress/gzip"
+	"io"
+)
+
+// Unwraps compressed data to the given io.Writer stream.
+type DecompressWriteCloser struct {
+	dst io.WriteCloser
+
+	cpw *io.PipeWriter
+	cpr *io.PipeReader
+	done chan bool
+}
+
+// NewDecompressWriteCloser takes an io.WriteCloser and wraps it in a type
+// that will decompress Writes to the io.WriteCloser as they are written.
+func (c *SCompress) NewDecompressWriteCloser(writeCloser io.WriteCloser, compressionType string) (*DecompressWriteCloser, error) {
+	pr, pw := io.Pipe()
+	done := make(chan bool)
+	go func() {
+		// goroutine adapted per Zhang Xiaofeng (2017)
+		defer pw.Close()
+		decompressReader, err := gzip.NewReader(pr)
+		defer decompressReader.Close()
+		if err != nil {
+			pw.CloseWithError(err)
+		}
+		io.Copy(writeCloser, decompressReader)
+		done <- true
+	}()
+	return &DecompressWriteCloser{
+		dst: writeCloser,
+
+		cpw: pw,
+		cpr: pr,
+		done: done,
+	}, nil
+}
+
+func (w *DecompressWriteCloser) Write(p []byte) (int, error) {
+	return w.cpw.Write(p) //write compressed bytes to the pipe
+}
+
+func (w *DecompressWriteCloser) Close() error {
+	// Close pipe, block until decompress is done, then close dest
+	w.cpr.Close()
+	_ = <-w.done
+	return w.dst.Close()
+}
+
+func (w *DecompressWriteCloser) open() error {
+	return nil
+}

--- a/lib/compress/decompress.go
+++ b/lib/compress/decompress.go
@@ -16,7 +16,8 @@ type DecompressWriteCloser struct {
 
 // NewDecompressWriteCloser takes an io.WriteCloser and wraps it in a type
 // that will decompress Writes to the io.WriteCloser as they are written.
-func (c *SCompress) NewDecompressWriteCloser(writeCloser io.WriteCloser, compressionType string) (*DecompressWriteCloser, error) {
+func (c *SCompress) NewDecompressWriteCloser(writeCloser io.WriteCloser) (*DecompressWriteCloser, error) {
+	// Supported compression format: gzip
 	pr, pw := io.Pipe()
 	done := make(chan bool)
 	go func() {


### PR DESCRIPTION
`db export` and `db download` now recognize when db backups are gzip compressed & automatically decompress before saving to local file.