### PR TITLE
Add postgres notes to restore & import command help

### DIFF
--- a/commands/db/contract.go
+++ b/commands/db/contract.go
@@ -106,6 +106,8 @@ var RestoreSubCmd = models.Command{
 	ShortHelp: "Restore a previously created backup",
 	LongHelp: "<code>db restore</code> restores a backup to your database. " +
 		"The restore job does not back up data before performing the database restore. Perform a backup prior to the restore if you have concerns about overwriting data. " +
+		"When restoring data to postgres, please close all open consoles and database connections before proceeding. " +
+		"If any users are connected to the database, postgres restore will fail. " +
 		"The restore command will confirm that you do not need to perform a backup. Once the restore job is started, the CLI will poll every few seconds until it finishes. " +
 		"Regardless of a successful restore or not, the logs for the restore will be printed to the console when the restore is finished. " +
 		"If an error occurs and the logs are not printed, you can use the db logs command to print out historical backup job logs. Here is a sample command\n\n" +
@@ -178,7 +180,9 @@ var ImportSubCmd = models.Command{
 		"When importing data into mongo, you may specify the database and collection to import into using the <code>-d</code> and <code>-c</code> flags respectively. " +
 		"Regardless of a successful import or not, the logs for the import will be printed to the console when the import is finished. " +
 		"Before an import takes place, your database is backed up automatically in case any issues arise. Here is a sample command\n\n" +
-		"<pre>\ndatica -E \"<your_env_name>\" db import db01 ./db.sql\n</pre>",
+		"<pre>\ndatica -E \"<your_env_name>\" db import db01 ./db.sql\n</pre>\n" +
+		"When importing data into postgres, import cannot DROP DATABASE \"catalyzeDB\". " +
+		"Ensure your import individually removes any neccessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.\n",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {
 		return func(subCmd *cli.Cmd) {
 			databaseName := subCmd.StringArg("DATABASE_NAME", "", "The name of the database to import data to (e.g. 'db01')")

--- a/commands/db/contract.go
+++ b/commands/db/contract.go
@@ -106,9 +106,10 @@ var RestoreSubCmd = models.Command{
 	ShortHelp: "Restore a previously created backup",
 	LongHelp: "<code>db restore</code> restores a backup to your database. " +
 		"The restore job does not back up data before performing the database restore. Perform a backup prior to the restore if you have concerns about overwriting data. " +
+		"The restore command will confirm that you do not need to perform a backup. " +
 		"When restoring data to postgres, please close all open consoles and database connections before proceeding. " +
 		"If any users are connected to the database, postgres restore will fail. " +
-		"The restore command will confirm that you do not need to perform a backup. Once the restore job is started, the CLI will poll every few seconds until it finishes. " +
+		"Once the restore job is started, the CLI will poll every few seconds until it finishes. " +
 		"Regardless of a successful restore or not, the logs for the restore will be printed to the console when the restore is finished. " +
 		"If an error occurs and the logs are not printed, you can use the db logs command to print out historical backup job logs. Here is a sample command\n\n" +
 		"<pre>\ndatica -E \"<your_env_name>\" db restore db01 00000000-0000-0000-0000-000000000000\n</pre>",
@@ -180,7 +181,7 @@ var ImportSubCmd = models.Command{
 		"When importing data into mongo, you may specify the database and collection to import into using the <code>-d</code> and <code>-c</code> flags respectively. " +
 		"Regardless of a successful import or not, the logs for the import will be printed to the console when the import is finished. " +
 		"Before an import takes place, your database is backed up automatically in case any issues arise. Here is a sample command\n\n" +
-		"<pre>\ndatica -E \"<your_env_name>\" db import db01 ./db.sql\n</pre>\n" +
+		"<pre>\ndatica -E \"<your_env_name>\" db import db01 ./db.sql\n</pre>\n\n" +
 		"When importing data into postgres, import cannot DROP DATABASE \"catalyzeDB\". " +
 		"Ensure your import individually removes any neccessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.\n",
 	CmdFunc: func(settings *models.Settings) func(cmd *cli.Cmd) {

--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -42,7 +42,7 @@ func CmdImport(databaseName, filePath, mongoCollection, mongoDatabase string, sk
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"datica services list\" command.", databaseName)
 	}
 	if service.Name == "postgres" {
-		fmt.Printf("WARNING: Import cannot DROP DATABASE \"catalyzeDB\". Ensure your import individually removes any neccessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.")
+		fmt.Printf("WARNING: Import cannot DROP DATABASE \"catalyzeDB\". Ensure your import individually removes any necessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.")
 	}
 	key := make([]byte, crypto.KeySize)
 	iv := make([]byte, crypto.IVSize)

--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -41,6 +41,9 @@ func CmdImport(databaseName, filePath, mongoCollection, mongoDatabase string, sk
 	if service == nil {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"datica services list\" command.", databaseName)
 	}
+	if service.Name == "postgres" {
+		fmt.Printf("WARNING: Import cannot DROP DATABASE \"catalyzeDB\". Ensure your import individually removes any neccessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.")
+	}
 	key := make([]byte, crypto.KeySize)
 	iv := make([]byte, crypto.IVSize)
 	rand.Read(key)

--- a/commands/db/import.go
+++ b/commands/db/import.go
@@ -41,8 +41,8 @@ func CmdImport(databaseName, filePath, mongoCollection, mongoDatabase string, sk
 	if service == nil {
 		return fmt.Errorf("Could not find a service with the label \"%s\". You can list services with the \"datica services list\" command.", databaseName)
 	}
-	if service.Name == "postgres" {
-		fmt.Printf("WARNING: Import cannot DROP DATABASE \"catalyzeDB\". Ensure your import individually removes any necessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.")
+	if service.Name == "postgresql" {
+		fmt.Println("WARNING: Import cannot DROP DATABASE \"catalyzeDB\". Ensure your import individually removes any necessary \"catalyzeDB\" objects, or import only into newly created postgres services where the \"catalyzeDB\" database is already empty.")
 	}
 	key := make([]byte, crypto.KeySize)
 	iv := make([]byte, crypto.IVSize)

--- a/commands/db/restore.go
+++ b/commands/db/restore.go
@@ -23,7 +23,7 @@ func CmdRestore(databaseName, backupID, mongoDatabase string, skipConfirm bool, 
 	pgWarn := fmt.Sprintf("WARNING: postgres restore will fail if any users are connected to the database. Before proceeding please close all open consoles and database connections. If needed, please contact Datica Support at https://datica.com/support to stop the \"%s\" service.", service.Label)
 	if !skipConfirm {
 		msg := "A database restore will be performed immediately. All current data will be lost if not included in the specified backup. No backup will be taken beforehand - please do so now if you need to."
-		if service.Name == "postgres" {
+		if service.Name == "postgresql" {
 			sep := " " //space
 			msg = strings.Join([]string{msg, pgWarn}, sep)
 		}
@@ -32,8 +32,8 @@ func CmdRestore(databaseName, backupID, mongoDatabase string, skipConfirm bool, 
 			return err
 		}
 	} else {
-		if service.Name == "postgres" {
-			fmt.Printf(pgWarn) // no prompt, but display the alert
+		if service.Name == "postgresql" {
+			fmt.Println(pgWarn) // no prompt, but display the alert
 		}
 	}
 	err = id.Restore(backupID, service, mongoDatabase)

--- a/commands/db/restore_test.go
+++ b/commands/db/restore_test.go
@@ -75,7 +75,7 @@ func TestDbRestore(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRestore(data.databaseName, data.backupID, data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+		err := CmdRestore(data.databaseName, data.backupID, "", data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
 
 		// assert
 		if err != nil {
@@ -109,7 +109,7 @@ func TestDbRestoreBackupNotFinished(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRestore(data.databaseName, data.backupID, data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+		err := CmdRestore(data.databaseName, data.backupID, "", data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
 
 		// assert
 		if err == nil {
@@ -141,7 +141,7 @@ func TestDbRestoreJobNotBackup(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRestore(data.databaseName, data.backupID, data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+		err := CmdRestore(data.databaseName, data.backupID, "", data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
 
 		// assert
 		if err == nil {
@@ -185,7 +185,7 @@ func TestDbRestoreRestoreNeverFinishes(t *testing.T) {
 		t.Logf("Data: %+v", data)
 
 		// test
-		err := CmdRestore(data.databaseName, data.backupID, data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
+		err := CmdRestore(data.databaseName, data.backupID, "", data.skipConfirm, New(settings, crypto.New(), compress.New(), jobs.New(settings)), &test.FakePrompts{}, services.New(settings))
 
 		// assert
 		if err == nil {


### PR DESCRIPTION
Add `db restore` notice:
> WARNING: postgres restore will fail if any users are connected to the database. Before proceeding please close all open consoles and database connections. If needed, please contact Datica Support at https://datica.com/support to stop the "%s" service.

and `db import` notice:
> WARNING: Import cannot DROP DATABASE "catalyzeDB". Ensure your import individually removes any necessary "catalyzeDB" objects, or import only into newly created postgres services where the "catalyzeDB" database is already empty.